### PR TITLE
feat: Verify conditions for conflicts in operation bundle

### DIFF
--- a/contracts/privacy-channel/src/test/test.rs
+++ b/contracts/privacy-channel/src/test/test.rs
@@ -5,7 +5,6 @@ use crate::{
     test::channel_operation_builder::ChannelOperationBuilder,
 };
 
-use alloc::borrow::ToOwned;
 use channel_auth_contract::contract::{
     ChannelAuthContract, ChannelAuthContractArgs, ChannelAuthContractClient,
 };

--- a/contracts/privacy-channel/src/transact.rs
+++ b/contracts/privacy-channel/src/transact.rs
@@ -1,13 +1,14 @@
 use moonlight_primitives::{
-    equal_condition_sequence, no_duplicate_addresses, verify_condition_does_not_conflict_with_set,
+    condition_does_not_conflict_with_set, equal_condition_sequence, no_duplicate_addresses,
     Condition,
 };
 use moonlight_utxo_core::core::{calculate_auth_requirements, InternalBundle};
 use soroban_sdk::{
+    assert_with_error,
     auth::{ContractContext, InvokerContractAuthEntry, SubContractInvocation},
     contracterror, contracttype, panic_with_error,
     token::TokenClient,
-    vec, xdr, Address, BytesN, Env, IntoVal, Symbol, Val, Vec,
+    vec, Address, BytesN, Env, IntoVal, Symbol, Val, Vec,
 };
 
 use crate::{
@@ -23,6 +24,7 @@ pub enum Error {
     RepeatedAccountForWithdraw = 102,
     ConflictingConditionsForAccount = 103,
     AmountOverflow = 104,
+    BundleHasConflictingConditions = 105,
 }
 
 #[derive(Clone)]
@@ -38,6 +40,12 @@ pub fn pre_process_channel_operation(
     e: &Env,
     op: ChannelOperation,
 ) -> (InternalBundle, i128, i128) {
+    assert_with_error!(
+        &e,
+        op_has_no_conflicting_conditions(&e, op.clone()),
+        Error::BundleHasConflictingConditions
+    );
+
     let mut total_deposit: i128 = 0;
     for (_addr, amt, _conds) in op.deposit.iter() {
         total_deposit = match total_deposit.checked_add(amt) {
@@ -54,8 +62,7 @@ pub fn pre_process_channel_operation(
         };
     }
 
-    let merged_deposit_and_withdraws =
-        join_external_operations(&e, op.deposit.clone(), op.withdraw.clone());
+    verify_external_operations(&e, op.deposit.clone(), op.withdraw.clone());
 
     let auth_req = calculate_auth_requirements(e, &op.spend); // &vec![&e]);
 
@@ -87,24 +94,6 @@ pub fn pre_process_channel_operation(
         extract_external_condition_lists(e, condition_lists);
 
     return (utxo_op, total_deposit, total_withdraw);
-}
-
-// Joins deposit and withdraw operations into a single Vec<(Address, Vec<Condition>)>.
-fn join_external_operations(
-    e: &Env,
-    deposit: Vec<(Address, i128, Vec<Condition>)>,
-    withdraw: Vec<(Address, i128, Vec<Condition>)>,
-) -> Vec<(Address, Vec<Condition>)> {
-    verify_external_operations(&e, deposit.clone(), withdraw.clone());
-
-    let mut combined: Vec<(Address, Vec<Condition>)> = Vec::new(&e);
-    for (addr, _, conditions) in deposit {
-        combined.push_back((addr, conditions));
-    }
-    for (addr, _, conditions) in withdraw {
-        combined.push_back((addr, conditions));
-    }
-    combined
 }
 
 fn extract_external_condition_lists(e: &Env, list: Vec<Vec<Condition>>) -> Vec<Condition> {
@@ -184,4 +173,23 @@ pub fn execute_external_operations(
         asset_client.transfer(&e.current_contract_address(), &to, &amount);
         decrease_supply(&e, amount);
     }
+}
+
+pub fn op_has_no_conflicting_conditions(e: &Env, op: ChannelOperation) -> bool {
+    let mut verified_conditions: Vec<Condition> = Vec::new(&e);
+
+    let mut conditions_to_check: Vec<Condition> = Vec::new(&e);
+    conditions_to_check.extend(op.spend.iter().flat_map(|(_, conds)| conds.clone()));
+    conditions_to_check.extend(op.deposit.iter().flat_map(|(_, _, conds)| conds.clone()));
+    conditions_to_check.extend(op.withdraw.iter().flat_map(|(_, _, conds)| conds.clone()));
+
+    for c in conditions_to_check.iter() {
+        let cond = c.clone();
+        if !condition_does_not_conflict_with_set(cond.clone(), verified_conditions.clone()) {
+            return false;
+        }
+        verified_conditions.push_back(cond);
+    }
+
+    true
 }

--- a/contracts/privacy-channel/src/treasury.rs
+++ b/contracts/privacy-channel/src/treasury.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{Address, Env};
+use soroban_sdk::Env;
 
 use crate::storage::{read_supply, write_supply_unchecked};
 

--- a/modules/auth/src/core.rs
+++ b/modules/auth/src/core.rs
@@ -111,7 +111,7 @@ pub trait UtxoAuthorizable {
                     }
 
                     match signer.clone() {
-                        SignerKey::P256(signer_pk) => {
+                        SignerKey::P256(_signer_pk) => {
                             // Lookup signature by key.
 
                             let (sig_variant, valid_until_ledger) =
@@ -133,6 +133,7 @@ pub trait UtxoAuthorizable {
                         }
                         _ => {
                             //Do nothing as we might have the provider signature along these
+                            continue;
                         }
                     }
                 }

--- a/modules/auth/src/test.rs
+++ b/modules/auth/src/test.rs
@@ -1,7 +1,5 @@
-use core::clone;
-
 use moonlight_helpers::testutils::keys::{Ed25519Account, P256KeyPair};
-use moonlight_primitives::{hash_payload, Condition, Signature, SignerKey};
+use moonlight_primitives::{Condition, Signature, SignerKey};
 use soroban_sdk::{testutils::Ledger, vec, xdr, Env, Error, Map};
 
 use crate::{core::verify_signature, testutils::contract::create_contract};

--- a/modules/primitives/src/lib.rs
+++ b/modules/primitives/src/lib.rs
@@ -223,22 +223,26 @@ pub fn equal_condition_sequence(e: &Env, a: &Vec<Condition>, b: &Vec<Condition>)
     true
 }
 
-pub fn verify_condition_does_not_conflict_with_set(
+pub fn condition_does_not_conflict_with_set(
     condition: Condition,
     condition_set: Vec<Condition>,
-) {
+) -> bool {
     for cond in condition_set.iter() {
         if cond.conflicts_with(&condition) {
-            panic!("Conflicting conditions detected");
+            return false;
         }
     }
+    true
 }
 
-pub fn verify_no_conflicting_conditions(
+pub fn has_no_conflicting_conditions_in_sets(
     conditions_a: Vec<Condition>,
     conditions_b: Vec<Condition>,
-) {
+) -> bool {
     for cond in conditions_a.iter() {
-        verify_condition_does_not_conflict_with_set(cond.clone(), conditions_b.clone());
+        if !condition_does_not_conflict_with_set(cond.clone(), conditions_b.clone()) {
+            return false;
+        }
     }
+    true
 }

--- a/modules/utxo-core/src/core.rs
+++ b/modules/utxo-core/src/core.rs
@@ -1,8 +1,7 @@
-use moonlight_helpers::parser::address_to_ed25519_pk_bytes;
 use moonlight_primitives::{no_duplicate_keys, AuthRequirements, Condition, SignerKey};
 use soroban_sdk::{
-    assert_with_error, contracterror, contracttrait, contracttype, panic_with_error, vec, Address,
-    Bytes, BytesN, Env, IntoVal, Map, Symbol, Vec,
+    assert_with_error, contracterror, contracttrait, contracttype, panic_with_error, vec, Bytes,
+    BytesN, Env, IntoVal, Map, Symbol, Vec,
 };
 
 use soroban_sdk::symbol_short;

--- a/modules/utxo-core/src/core.rs
+++ b/modules/utxo-core/src/core.rs
@@ -104,14 +104,19 @@ pub trait UtxoHandlerTrait {
     ) -> i128 {
         let mut total_available_balance = incoming_amount;
 
-        if !no_duplicate_keys(&e, bundle.spend.iter(), |spend_utxo| spend_utxo.clone()) {
-            panic_with_error!(&e, Error::RepeatedSpendUTXO);
-        }
-        if !no_duplicate_keys(&e, bundle.create.iter(), |(create_utxo, _amt)| {
-            create_utxo.clone()
-        }) {
-            panic_with_error!(&e, Error::RepeatedCreateUTXO);
-        }
+        assert_with_error!(
+            &e,
+            no_duplicate_keys(&e, bundle.spend.iter(), |spend_utxo| spend_utxo.clone()),
+            Error::RepeatedSpendUTXO
+        );
+
+        assert_with_error!(
+            &e,
+            no_duplicate_keys(&e, bundle.create.iter(), |(create_utxo, _amt)| {
+                create_utxo.clone()
+            }),
+            Error::RepeatedCreateUTXO
+        );
 
         Self::auth(&e).require_auth_for_args(vec![&e, bundle.req.clone().into_val(e)]);
 


### PR DESCRIPTION
This pull request introduces significant improvements to how conflicting conditions are detected and handled in channel and UTXO operations. The main changes involve refactoring the logic for condition conflict detection to use more idiomatic Rust boolean-returning functions, replacing panic-based error handling with assertions and error propagation, and updating usages across multiple modules to ensure consistency and clearer error reporting.

### Condition conflict detection improvements

* Replaced `verify_condition_does_not_conflict_with_set` and `verify_no_conflicting_conditions` functions with new boolean-returning functions `condition_does_not_conflict_with_set` and `has_no_conflicting_conditions_in_sets` in `modules/primitives/src/lib.rs`, making conflict checks more idiomatic and testable.
* Updated all usages of the old conflict detection functions in test helpers (`channel_operation_builder.rs` and `operation_bundle.rs`) to use the new assertion-based approach, providing clearer error messages when conflicts are detected. [[1]](diffhunk://#diff-418fc0959b9d57850a64ecdb06550dc40b5fe8fe2a0de7984c259763075071dfL72-R74) [[2]](diffhunk://#diff-418fc0959b9d57850a64ecdb06550dc40b5fe8fe2a0de7984c259763075071dfL85-R93) [[3]](diffhunk://#diff-418fc0959b9d57850a64ecdb06550dc40b5fe8fe2a0de7984c259763075071dfL102-R116) [[4]](diffhunk://#diff-418fc0959b9d57850a64ecdb06550dc40b5fe8fe2a0de7984c259763075071dfL114-R134) [[5]](diffhunk://#diff-d7edacef9091e7473f1bcc9473aaf6f78968d45c47fd676f668820dde21e58c7L68-R74) [[6]](diffhunk://#diff-d7edacef9091e7473f1bcc9473aaf6f78968d45c47fd676f668820dde21e58c7L84-R95)

### Error handling and validation

* Introduced a new error type `BundleHasConflictingConditions` in `contracts/privacy-channel/src/transact.rs` and added an early assertion in `pre_process_channel_operation` to check for conflicting conditions across all operation types, improving robustness and error reporting. [[1]](diffhunk://#diff-a15a21e13f55512aecd5d679e99e641578ad0488b6111a66041fdf92eab7986eR27) [[2]](diffhunk://#diff-a15a21e13f55512aecd5d679e99e641578ad0488b6111a66041fdf92eab7986eR43-R48)
* Replaced panic-based duplicate key checks in UTXO handler logic with assertion-based error handling for repeated spend/create UTXOs, aligning with the new error propagation approach.

### Codebase cleanup and consistency

* Removed unused imports and cleaned up code in several files, including test files and module implementations, for better readability and maintainability. [[1]](diffhunk://#diff-17c763c84c6baab71c1dd767575436f3448d6cc85bc7e1a3c3c25e7b6fe6c48bL1-R2) [[2]](diffhunk://#diff-51409251d235d114e4f31a6601385ffbce3994dbe7535a094c51a2f97136cde1L1-R4) [[3]](diffhunk://#diff-53c62252542c0199fa23728de7654fd876f4123cfb303bc5125618ab09a83fb8L1-R1) [[4]](diffhunk://#diff-1627b672cabc770dcab744439d44fec238bd3d61be2946667c0d9abe9195086dL8)
* Updated function signatures and usages to reflect the new conflict detection logic, ensuring consistent behavior throughout the codebase. [[1]](diffhunk://#diff-d7edacef9091e7473f1bcc9473aaf6f78968d45c47fd676f668820dde21e58c7L3-R3) [[2]](diffhunk://#diff-a15a21e13f55512aecd5d679e99e641578ad0488b6111a66041fdf92eab7986eL2-R11)

### UTXO and channel operation logic

* Removed the now-redundant `join_external_operations` function and replaced its usage with direct validation calls, simplifying the channel operation preprocessing flow. [[1]](diffhunk://#diff-a15a21e13f55512aecd5d679e99e641578ad0488b6111a66041fdf92eab7986eL57-R65) [[2]](diffhunk://#diff-a15a21e13f55512aecd5d679e99e641578ad0488b6111a66041fdf92eab7986eL92-L109)
* Added a new helper function `op_has_no_conflicting_conditions` to aggregate and check all conditions in a channel operation for conflicts, used as part of the new validation step.

### Minor fixes

* Fixed logic in signature verification to correctly continue processing when encountering non-P256 keys, preventing unnecessary errors in multi-provider scenarios. [[1]](diffhunk://#diff-cb556c85a49194d8134655207287780b3e66fa85295551bfb2ae4f41d7515f58L114-R114) [[2]](diffhunk://#diff-cb556c85a49194d8134655207287780b3e66fa85295551bfb2ae4f41d7515f58R136)