### PR TITLE
fix: handle empty deposit conditions and auth requirements in operations

### DIFF
--- a/contracts/privacy-channel/Cargo.toml
+++ b/contracts/privacy-channel/Cargo.toml
@@ -30,3 +30,4 @@ moonlight-utxo-core = { workspace = true, features = ["testutils"] }
 channel-auth-contract = { workspace = true  }
 moonlight-helpers = { workspace = true, features = ["testutils"] }
 token-contract = { workspace = true , features = ["testutils"] }
+

--- a/contracts/privacy-channel/src/test/channel_operation_builder.rs
+++ b/contracts/privacy-channel/src/test/channel_operation_builder.rs
@@ -203,12 +203,16 @@ impl ChannelOperationBuilder {
             .expect("Depositor address not found in deposit list");
 
         // CHANNEL TRANSACT with ARGS: [DEPOSIT_CONDITIONS]
-        let root_args: Vec<Val> = vec![
-            &e,
-            deposit_conditions
-                .try_into_val(e)
-                .unwrap_or_else(|_| panic!("intoval")),
-        ];
+        let root_args: Vec<Val> = if deposit_conditions.len() == 0 {
+            vec![&e, ().into_val(e)]
+        } else {
+            vec![
+                &e,
+                deposit_conditions
+                    .try_into_val(e)
+                    .unwrap_or_else(|_| panic!("intoval")),
+            ]
+        };
 
         // TRANSFER: From, To, Amount
         let sub_args: Vec<Val> = vec![

--- a/modules/utxo-core/src/core.rs
+++ b/modules/utxo-core/src/core.rs
@@ -117,7 +117,13 @@ pub trait UtxoHandlerTrait {
             Error::RepeatedCreateUTXO
         );
 
-        Self::auth(&e).require_auth_for_args(vec![&e, bundle.req.clone().into_val(e)]);
+        let auth_args = if bundle.req.0.len() == 0 {
+            vec![&e]
+        } else {
+            vec![&e, bundle.req.clone().into_val(e)]
+        };
+
+        Self::auth(&e).require_auth_for_args(auth_args);
 
         for spend_utxo in bundle.spend.iter() {
             let unspent_balance = Self::spend(&e, spend_utxo.clone());

--- a/modules/utxo-core/src/testutils/operation_bundle.rs
+++ b/modules/utxo-core/src/testutils/operation_bundle.rs
@@ -197,12 +197,18 @@ impl UTXOOperationBuilder {
 
     pub fn get_contract_auth_args(&self, e: &Env) -> Vec<Val> {
         let auth_req = self.calculate_auth_requirements(&e);
-        let args: Vec<Val> = vec![
-            &e,
-            auth_req
-                .try_into_val(e)
-                .unwrap_or_else(|_| panic!("intoval")),
-        ];
+
+        let args: Vec<Val> = if auth_req.0.len() == 0 {
+            vec![&e]
+        } else {
+            vec![
+                &e,
+                auth_req
+                    .try_into_val(e)
+                    .unwrap_or_else(|_| panic!("intoval")),
+            ]
+        };
+
         args
     }
 


### PR DESCRIPTION
This pull request introduces improvements to the handling of authorization arguments in both the privacy channel and UTXO core modules, as well as adds a new test for deposit operations with authorization. The main changes focus on ensuring that empty argument lists are handled correctly and consistently across the codebase, and on strengthening test coverage for deposit flows.

**Authorization argument handling improvements:**

* Updated the construction of authorization argument vectors in `ChannelOperationBuilder`, `UtxoHandlerTrait`, and `UTXOOperationBuilder` to correctly handle cases where the input list is empty, ensuring that only the environment is passed when there are no conditions or requirements. [[1]](diffhunk://#diff-418fc0959b9d57850a64ecdb06550dc40b5fe8fe2a0de7984c259763075071dfL206-R215) [[2]](diffhunk://#diff-51409251d235d114e4f31a6601385ffbce3994dbe7535a094c51a2f97136cde1L120-R126) [[3]](diffhunk://#diff-d7edacef9091e7473f1bcc9473aaf6f78968d45c47fd676f668820dde21e58c7L200-R211)

**Test coverage enhancements:**

* Added a new test `test_single_deposit_with_auth` in `contracts/privacy-channel/src/test/test.rs` to verify deposit operations with provider and user authorization, including signature checks and state assertions.

**Minor test module improvements:**

* Added `extern crate std` to the test module to ensure compatibility with standard library features in the test environment.
* Updated imports and test setup in `contracts/privacy-channel/src/test/test.rs` for clarity and completeness.

**Miscellaneous:**

* Minor update to the Cargo manifest to ensure consistent workspace feature usage for dependencies.