### PR TITLE
feat: add drawer storage optimization for contract

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ moonlight-utxo-core = { path = "modules/utxo-core" }
 moonlight-auth = { path = "modules/auth" }
 moonlight-helpers = { path = "modules/helpers" }
 moonlight-primitives = { path = "modules/primitives" }
+moonlight-storage = { path = "modules/storage" }
 
 channel-auth-contract = { path = "contracts/channel-auth" }
 token-contract = { path = "contracts/token" }

--- a/contracts/privacy-channel/Cargo.toml
+++ b/contracts/privacy-channel/Cargo.toml
@@ -17,7 +17,7 @@ testutils = ["soroban-sdk/testutils", "moonlight-utxo-core/testutils"]
 [dependencies]
 soroban-sdk = { workspace = true }
 admin-sep = { workspace = true}
-moonlight-utxo-core = { workspace = true , features = [] }
+moonlight-utxo-core = { workspace = true , features = [ "no-utxo-events", "no-bundle-events"] }
 moonlight-auth = { workspace = true }
 moonlight-primitives = { workspace = true }
 wee_alloc = {workspace = true}

--- a/contracts/privacy-channel/src/test/channel_operation_builder.rs
+++ b/contracts/privacy-channel/src/test/channel_operation_builder.rs
@@ -142,7 +142,6 @@ impl ChannelOperationBuilder {
         for (existing_address, _, conditions) in self.deposit.iter() {
             if existing_address == address {
                 return AuthPayload {
-                    contract: self.utxo_builder.channel_contract.clone(),
                     conditions: conditions.clone(),
                     live_until_ledger,
                 };
@@ -152,7 +151,6 @@ impl ChannelOperationBuilder {
         for (existing_address, _, conditions) in self.withdraw.iter() {
             if existing_address == address {
                 return AuthPayload {
-                    contract: self.utxo_builder.channel_contract.clone(),
                     conditions: conditions.clone(),
                     live_until_ledger,
                 };
@@ -169,7 +167,16 @@ impl ChannelOperationBuilder {
         live_until_ledger: u32,
     ) -> Hash<32> {
         let payload = self.get_auth_payload_for_address(address, live_until_ledger);
-        hash_payload(&e, &payload)
+        hash_payload(
+            &e,
+            &payload,
+            &self
+                .utxo_builder
+                .channel_contract
+                .clone()
+                .to_string()
+                .to_bytes(),
+        )
     }
 
     pub fn add_deposit_signature(

--- a/contracts/privacy-channel/src/transact.rs
+++ b/contracts/privacy-channel/src/transact.rs
@@ -78,35 +78,35 @@ pub fn pre_process_channel_operation(
         req: auth_req,
     };
 
-    let mut condition_lists: Vec<Vec<Condition>> = Vec::new(&e);
-    for (_, conds) in op.spend.iter() {
-        condition_lists.push_back(conds.clone());
-    }
-    for (_, _, conds) in op.deposit.iter() {
-        condition_lists.push_back(conds.clone());
-    }
-    for (_, _, conds) in op.withdraw.iter() {
-        condition_lists.push_back(conds.clone());
-    }
+    // let mut condition_lists: Vec<Vec<Condition>> = Vec::new(&e);
+    // for (_, conds) in op.spend.iter() {
+    //     condition_lists.push_back(conds.clone());
+    // }
+    // for (_, _, conds) in op.deposit.iter() {
+    //     condition_lists.push_back(conds.clone());
+    // }
+    // for (_, _, conds) in op.withdraw.iter() {
+    //     condition_lists.push_back(conds.clone());
+    // }
 
-    // TODO: REVIEW CONDITIONS AGAINST RESULTS
-    let _external_condition_list: Vec<Condition> =
-        extract_external_condition_lists(e, condition_lists);
+    // // TODO: REVIEW CONDITIONS AGAINST RESULTS
+    // let _external_condition_list: Vec<Condition> =
+    //     extract_external_condition_lists(e, condition_lists);
 
     return (utxo_op, total_deposit, total_withdraw);
 }
 
-fn extract_external_condition_lists(e: &Env, list: Vec<Vec<Condition>>) -> Vec<Condition> {
-    let mut merged = Vec::new(&e);
-    for conditions in list {
-        for cond in conditions {
-            if !merged.contains(&cond) {
-                merged.push_back(cond);
-            }
-        }
-    }
-    merged
-}
+// fn extract_external_condition_lists(e: &Env, list: Vec<Vec<Condition>>) -> Vec<Condition> {
+//     let mut merged = Vec::new(&e);
+//     for conditions in list {
+//         for cond in conditions {
+//             if !merged.contains(&cond) {
+//                 merged.push_back(cond);
+//             }
+//         }
+//     }
+//     merged
+// }
 
 fn verify_external_operations(
     e: &Env,

--- a/modules/auth/src/core.rs
+++ b/modules/auth/src/core.rs
@@ -101,7 +101,7 @@ pub trait UtxoAuthorizable {
                 let inner: Map<SignerKey, Vec<Condition>> = reqs.0;
 
                 let caller_contract = cc.contract;
-
+                let caller_contract_bytes: Bytes = caller_contract.clone().to_string().to_bytes();
                 for signer in inner.keys().iter() {
                     let conds: Vec<Condition> = inner.get(signer.clone()).unwrap(); // or handle Option
                                                                                     // Use the signer key (signer) and its conditions (conds)
@@ -122,12 +122,12 @@ pub trait UtxoAuthorizable {
                             }
 
                             let auth_payload = AuthPayload {
-                                contract: caller_contract.clone(),
                                 conditions: conds,
                                 live_until_ledger: valid_until_ledger,
                             };
 
-                            let msg = hash_payload(&e, &auth_payload);
+                            let msg =
+                                hash_payload(&e, &auth_payload, &caller_contract_bytes.clone());
 
                             verify_signature(&e, &signer, &sig_variant, &msg)?;
                         }

--- a/modules/primitives/src/lib.rs
+++ b/modules/primitives/src/lib.rs
@@ -98,7 +98,6 @@ pub enum Signature {
 #[derive(Clone)]
 #[contracttype]
 pub struct AuthPayload {
-    pub contract: Address,
     pub conditions: Vec<Condition>,
     pub live_until_ledger: u32,
 }
@@ -120,18 +119,18 @@ pub struct AuthPayload {
 /// the conditions in the same ordering as they are defined in the original bundle  to ensure
 /// deterministic payloads.
 ///
-pub fn hash_payload(e: &Env, auth_payload: &AuthPayload) -> Hash<32> {
+pub fn hash_payload(e: &Env, auth_payload: &AuthPayload, contract: &Bytes) -> Hash<32> {
     let mut b = Bytes::new(&e);
-    b.append(&auth_payload.contract.clone().to_string().to_bytes());
+    b.append(&contract);
 
     let mut b_create = Bytes::new(&e);
-    b_create.append(&Bytes::from_slice(&e, b"CREATE"));
+    // b_create.append(&Bytes::from_slice(&e, b"CREATE"));
     let mut b_deposit = Bytes::new(&e);
-    b_deposit.append(&Bytes::from_slice(&e, b"DEPOSIT"));
+    // b_deposit.append(&Bytes::from_slice(&e, b"DEPOSIT"));
     let mut b_withdraw = Bytes::new(&e);
-    b_withdraw.append(&Bytes::from_slice(&e, b"WITHDRAW"));
+    // b_withdraw.append(&Bytes::from_slice(&e, b"WITHDRAW"));
     let mut b_integrate = Bytes::new(&e);
-    b_integrate.append(&Bytes::from_slice(&e, b"INTEGRATE"));
+    // b_integrate.append(&Bytes::from_slice(&e, b"INTEGRATE"));
 
     for cond in auth_payload.conditions.iter() {
         match cond {

--- a/modules/storage/Cargo.toml
+++ b/modules/storage/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "moonlight-storage"
+description = "Storage Module"
+version = "1.0.0"
+edition = "2021"
+
+
+[lib]
+crate-type = ["rlib"]
+doctest = false
+
+[features]
+storage-simple = []
+storage-drawer = []
+
+
+
+[dependencies]
+soroban-sdk = { git = "https://github.com/AhaLabs/rs-soroban-sdk", rev = "5a99659f1483c926ff87ea45f8823b8c00dc4cbd" }
+

--- a/modules/storage/src/drawer.rs
+++ b/modules/storage/src/drawer.rs
@@ -1,0 +1,309 @@
+/* =========================
+Drawer optimized storage with injected cache
+Layout:
+- Per UTXO entry stores amount, drawer_id, slot_idx (never deleted)
+- Per drawer entry stores bitmap Bytes of fixed size
+- Cache passed from contract layer accumulates changes
+========================= */
+
+use soroban_sdk::{contracttype, panic_with_error, Bytes, BytesN, Env, Map};
+
+use crate::{DrawerKey, Error, UTXOCoreDataKey, UtxoStore};
+
+#[derive(Clone)]
+#[contracttype]
+pub struct UtxoMeta {
+    pub amount: i128,
+    pub drawer_id: u32,
+    pub slot_idx: u32,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct DrawerState {
+    pub current_drawer: u32,
+    pub next_slot: u32,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub enum DrawerDataKey {
+    Drawer(DrawerKey), // value: Bytes bitmap
+    State,             // value: DrawerState
+}
+
+// The cache that gets passed through all operations
+pub struct DrawerCache {
+    pub drawers: Map<u32, Bytes>,      // drawer_id -> bitmap
+    pub state: Option<DrawerState>,    // Cached drawer state
+    pub state_dirty: bool,             // Track if state needs writing
+    pub dirty_drawers: Map<u32, bool>, // Track which drawers need writing
+}
+
+impl DrawerCache {
+    pub fn new(e: &Env) -> Self {
+        DrawerCache {
+            drawers: Map::new(e),
+            state: None,
+            state_dirty: false,
+            dirty_drawers: Map::new(e),
+        }
+    }
+
+    // Commit all cached changes to storage
+    pub fn commit(&self, e: &Env) {
+        // Write state if it was modified
+        if self.state_dirty {
+            if let Some(ref state) = self.state {
+                e.storage().persistent().set(&DrawerDataKey::State, state);
+            }
+        }
+
+        // Write all dirty drawers
+        for (drawer_id, _) in self.dirty_drawers.iter() {
+            if let Some(bitmap) = self.drawers.get(drawer_id) {
+                e.storage()
+                    .persistent()
+                    .set(&DrawerStore::drawer_key(drawer_id), &bitmap);
+            }
+        }
+    }
+}
+
+pub struct DrawerStore;
+
+impl DrawerStore {
+    const SLOTS_PER_DRAWER: u32 = 1024; // 128 bytes - medium-large
+
+    const BITMAP_BYTES: u32 = Self::SLOTS_PER_DRAWER / 8;
+
+    #[inline(always)]
+    fn utxo_key(e: &Env, utxo65: &BytesN<65>) -> UTXOCoreDataKey {
+        UTXOCoreDataKey::UTXO(<DrawerStore as UtxoStore>::hash_utxo_key(e, utxo65))
+    }
+
+    #[inline(always)]
+    pub fn drawer_key(id: u32) -> DrawerDataKey {
+        DrawerDataKey::Drawer(DrawerKey { id })
+    }
+
+    // Get state from cache or load from storage (no write back yet)
+    #[inline(always)]
+    fn get_state_cached(e: &Env, cache: &mut DrawerCache) -> DrawerState {
+        if cache.state.is_none() {
+            cache.state = Some(
+                e.storage()
+                    .persistent()
+                    .get::<_, DrawerState>(&DrawerDataKey::State)
+                    .unwrap_or(DrawerState {
+                        current_drawer: 1,
+                        next_slot: 0,
+                    }),
+            );
+        }
+        cache.state.clone().unwrap()
+    }
+
+    // Allocate slot using cached state
+    #[inline(always)]
+    fn alloc_slot_and_rotate_if_needed_cached(e: &Env, cache: &mut DrawerCache) -> (u32, u32) {
+        let mut state = Self::get_state_cached(e, cache);
+
+        // Check rotation
+        if state.next_slot >= Self::SLOTS_PER_DRAWER {
+            // When rotating, we might want to flush the previous drawer's bitmap
+            // to free up cache space, but only if it's dirty
+
+            // Find if the current drawer is in dirty_drawers
+            let mut found_dirty = false;
+            for i in 0..cache.dirty_drawers.keys().len() {
+                if let Some(key) = cache.dirty_drawers.keys().get(i) {
+                    if key == state.current_drawer {
+                        found_dirty = true;
+                        break;
+                    }
+                }
+            }
+
+            if found_dirty {
+                let old_drawer_id = state.current_drawer;
+                if let Some(bitmap) = cache.drawers.get(old_drawer_id) {
+                    e.storage()
+                        .persistent()
+                        .set(&Self::drawer_key(old_drawer_id), &bitmap);
+                    cache.drawers.remove(old_drawer_id);
+                    cache.dirty_drawers.remove(old_drawer_id);
+                }
+            }
+
+            state.current_drawer = state
+                .current_drawer
+                .checked_add(1)
+                .expect("drawer overflow");
+            state.next_slot = 0;
+        }
+
+        let drawer_id = state.current_drawer;
+        let slot_idx = state.next_slot;
+        state.next_slot += 1;
+
+        // Update cache instead of storage
+        cache.state = Some(state);
+        cache.state_dirty = true; // Mark state as needing write
+
+        (drawer_id, slot_idx)
+    }
+
+    // Get bitmap from cache or load from storage
+    #[inline(always)]
+    fn get_or_create_bitmap_cached(e: &Env, cache: &mut DrawerCache, drawer_id: u32) -> Bytes {
+        // Check cache first
+        if let Some(bitmap) = cache.drawers.get(drawer_id) {
+            return bitmap;
+        }
+
+        // Load from storage and cache it
+        let bitmap = e
+            .storage()
+            .persistent()
+            .get::<_, Bytes>(&Self::drawer_key(drawer_id))
+            .unwrap_or_else(|| {
+                let mut b = Bytes::new(e);
+                for _ in 0..Self::BITMAP_BYTES {
+                    b.push_back(0u8);
+                }
+                b
+            });
+
+        cache.drawers.set(drawer_id, bitmap.clone());
+        bitmap
+    }
+
+    #[inline(always)]
+    fn is_bit_set(bitmap: &Bytes, slot_idx: u32) -> bool {
+        let byte_i = slot_idx >> 3;
+        let bit_mask = 1u8 << (slot_idx & 7);
+        let byte = bitmap.get(byte_i).unwrap_or(0);
+        (byte & bit_mask) != 0
+    }
+
+    #[inline(always)]
+    fn set_bit_in_bitmap(bitmap: &mut Bytes, slot_idx: u32, val: bool) -> bool {
+        let byte_i = slot_idx >> 3;
+        let bit_mask = 1u8 << (slot_idx & 7);
+        let old = bitmap.get(byte_i).unwrap_or(0);
+        let new = if val { old | bit_mask } else { old & !bit_mask };
+
+        if old != new {
+            bitmap.set(byte_i, new);
+            return true;
+        }
+        false
+    }
+
+    // New methods that accept cache
+    pub fn utxo_balance_cached(e: &Env, cache: &mut DrawerCache, utxo65: &BytesN<65>) -> i128 {
+        let k = Self::utxo_key(e, &utxo65);
+        match e.storage().persistent().get::<_, UtxoMeta>(&k) {
+            Some(UtxoMeta {
+                amount,
+                drawer_id,
+                slot_idx,
+            }) => {
+                let bitmap = Self::get_or_create_bitmap_cached(e, cache, drawer_id);
+                if Self::is_bit_set(&bitmap, slot_idx) {
+                    amount
+                } else {
+                    0
+                }
+            }
+            None => -1,
+        }
+    }
+
+    pub fn create_cached(e: &Env, cache: &mut DrawerCache, utxo65: &BytesN<65>, amount: i128) {
+        if amount <= 0 {
+            panic_with_error!(e, Error::InvalidCreateAmount);
+        }
+
+        let uk = Self::utxo_key(e, &utxo65);
+
+        if let Some(UtxoMeta {
+            drawer_id,
+            slot_idx,
+            ..
+        }) = e.storage().persistent().get::<_, UtxoMeta>(&uk)
+        {
+            let bitmap = Self::get_or_create_bitmap_cached(e, cache, drawer_id);
+            if Self::is_bit_set(&bitmap, slot_idx) {
+                panic_with_error!(e, Error::UTXOAlreadyExists);
+            }
+        }
+
+        // Use cached allocation
+        let (drawer_id, slot_idx) = Self::alloc_slot_and_rotate_if_needed_cached(e, cache);
+
+        // Store UTXO (this still goes directly to storage)
+        e.storage().persistent().set(
+            &uk,
+            &UtxoMeta {
+                amount,
+                drawer_id,
+                slot_idx,
+            },
+        );
+
+        // Update bitmap in cache
+        let mut bitmap = Self::get_or_create_bitmap_cached(e, cache, drawer_id);
+        Self::set_bit_in_bitmap(&mut bitmap, slot_idx, true);
+        cache.drawers.set(drawer_id, bitmap);
+        cache.dirty_drawers.set(drawer_id, true);
+    }
+
+    pub fn spend_cached(e: &Env, cache: &mut DrawerCache, utxo65: &BytesN<65>) -> i128 {
+        let uk = Self::utxo_key(e, &utxo65);
+        match e.storage().persistent().get::<_, UtxoMeta>(&uk) {
+            Some(UtxoMeta {
+                amount,
+                drawer_id,
+                slot_idx,
+            }) => {
+                // Get bitmap from cache
+                let mut bitmap = Self::get_or_create_bitmap_cached(e, cache, drawer_id);
+
+                if !Self::is_bit_set(&bitmap, slot_idx) {
+                    panic_with_error!(e, Error::UTXOAlreadySpent);
+                }
+
+                // Update bitmap in cache only
+                Self::set_bit_in_bitmap(&mut bitmap, slot_idx, false);
+                cache.drawers.set(drawer_id, bitmap);
+                cache.dirty_drawers.set(drawer_id, true);
+
+                amount
+            }
+            None => panic_with_error!(e, Error::UTXONotFound),
+        }
+    }
+}
+
+// Keep the old trait impl for backward compatibility
+impl UtxoStore for DrawerStore {
+    fn utxo_balance(e: &Env, utxo65: &BytesN<65>) -> i128 {
+        let mut cache = DrawerCache::new(e);
+        Self::utxo_balance_cached(e, &mut cache, &utxo65)
+    }
+
+    fn create(e: &Env, utxo65: &BytesN<65>, amount: i128) {
+        let mut cache = DrawerCache::new(e);
+        Self::create_cached(e, &mut cache, &utxo65, amount);
+        cache.commit(e);
+    }
+
+    fn spend(e: &Env, utxo65: &BytesN<65>) -> i128 {
+        let mut cache = DrawerCache::new(e);
+        let result = Self::spend_cached(e, &mut cache, &utxo65);
+        cache.commit(e);
+        result
+    }
+}

--- a/modules/storage/src/lib.rs
+++ b/modules/storage/src/lib.rs
@@ -1,0 +1,76 @@
+#![no_std]
+
+// pick exactly one
+#[cfg(all(feature = "storage-simple", feature = "storage-drawer"))]
+compile_error!("Enable only one of storage-simple or storage-drawer");
+#[cfg(not(any(feature = "storage-simple", feature = "storage-drawer")))]
+compile_error!("Enable one of storage-simple or storage-drawer");
+
+// submodules
+#[cfg(feature = "storage-drawer")]
+mod drawer;
+#[cfg(feature = "storage-simple")]
+mod simple;
+
+// re exports, single name
+#[cfg(feature = "storage-simple")]
+pub type Store = simple::SimpleStore;
+#[cfg(feature = "storage-drawer")]
+pub type Store = drawer::DrawerStore;
+
+#[cfg(feature = "storage-drawer")]
+pub use drawer::{DrawerCache, DrawerStore};
+
+#[cfg(feature = "storage-drawer")]
+pub const IS_DRAWER: bool = true;
+#[cfg(feature = "storage-simple")]
+pub const IS_DRAWER: bool = false;
+
+// storage.rs
+use soroban_sdk::{contracterror, contracttype};
+use soroban_sdk::{Bytes, BytesN, Env};
+
+#[derive(Clone)]
+#[contracttype]
+pub enum UtxoState {
+    Unspent(i128),
+    Spent,
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub enum UTXOCoreDataKey {
+    UTXO(BytesN<32>),
+    // Drawer entries live under DrawerKey below for the optimized impl
+}
+
+#[derive(Clone)]
+#[contracttype]
+pub struct DrawerKey {
+    pub id: u32, // sequential drawer id
+}
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    UTXOAlreadyExists = 1,
+    UTXODoesntExist = 2,
+    UTXOAlreadySpent = 3,
+    UnbalancedBundle = 4,
+    InvalidCreateAmount = 5,
+    RepeatedCreateUTXO = 6,
+    RepeatedSpendUTXO = 7,
+    UTXONotFound = 8,
+}
+
+pub trait UtxoStore {
+    fn utxo_balance(e: &Env, utxo65: &BytesN<65>) -> i128;
+    fn create(e: &Env, utxo65: &BytesN<65>, amount: i128);
+    fn spend(e: &Env, utxo65: &BytesN<65>) -> i128;
+    fn hash_utxo_key(e: &Env, utxo65: &BytesN<65>) -> BytesN<32> {
+        let b = Bytes::from_slice(e, utxo65.to_array().as_ref());
+        let h = e.crypto().sha256(&b);
+        BytesN::<32>::from_array(e, &h.to_array())
+    }
+}

--- a/modules/storage/src/simple.rs
+++ b/modules/storage/src/simple.rs
@@ -1,0 +1,51 @@
+/* =========================
+Simple storage
+========================= */
+
+use soroban_sdk::{panic_with_error, BytesN, Env};
+
+use crate::{Error, UTXOCoreDataKey, UtxoState, UtxoStore};
+
+pub struct SimpleStore;
+
+impl SimpleStore {
+    fn key(e: &Env, utxo65: &BytesN<65>) -> UTXOCoreDataKey {
+        UTXOCoreDataKey::UTXO(<SimpleStore as UtxoStore>::hash_utxo_key(e, utxo65))
+    }
+}
+
+impl UtxoStore for SimpleStore {
+    fn utxo_balance(e: &Env, utxo65: BytesN<65>) -> i128 {
+        match e
+            .storage()
+            .persistent()
+            .get::<_, UtxoState>(&Self::key(e, &utxo65))
+        {
+            Some(UtxoState::Unspent(a)) => a,
+            Some(UtxoState::Spent) => 0,
+            None => -1,
+        }
+    }
+
+    fn create(e: &Env, utxo65: BytesN<65>, amount: i128) {
+        let k = Self::key(e, &utxo65);
+        if e.storage().persistent().get::<_, UtxoState>(&k).is_some() {
+            panic_with_error!(e, Error::UTXOAlreadyExists);
+        }
+        e.storage()
+            .persistent()
+            .set(&k, &UtxoState::Unspent(amount));
+    }
+
+    fn spend(e: &Env, utxo65: BytesN<65>) -> i128 {
+        let k = Self::key(e, &utxo65);
+        match e.storage().persistent().get::<_, UtxoState>(&k) {
+            Some(UtxoState::Unspent(a)) => {
+                e.storage().persistent().set(&k, &UtxoState::Spent);
+                a
+            }
+            Some(UtxoState::Spent) => panic_with_error!(e, Error::UTXOAlreadySpent),
+            None => panic_with_error!(e, Error::UTXODoesntExist),
+        }
+    }
+}

--- a/modules/utxo-core/Cargo.toml
+++ b/modules/utxo-core/Cargo.toml
@@ -9,7 +9,10 @@ edition = "2021"
 testutils = [ "soroban-sdk/testutils", "moonlight-helpers/testutils", ] 
 no-utxo-events = [] # disable utxo events for cost optimization on bigger batches
 no-bundle-events = [ ] # disable bundle events for cost optimization on bigger batches
+default = ["storage-drawer", "no-utxo-events", "no-bundle-events"] # default features
 
+storage-drawer = ["moonlight-storage/storage-drawer"]
+storage-simple = ["moonlight-storage/storage-simple"]
 
 [lib]
 crate-type = ["rlib"]
@@ -21,6 +24,7 @@ doctest = false
 soroban-sdk = { git = "https://github.com/AhaLabs/rs-soroban-sdk", rev = "5a99659f1483c926ff87ea45f8823b8c00dc4cbd" }
 moonlight-helpers = { workspace = true }
 moonlight-primitives = { workspace = true }
+moonlight-storage = { workspace = true }
 # soroban-sdk = { workspace = true }
 # p256 = { version = "0.13.2", default-features = false, features = ["ecdsa", "arithmetic"],optional = true }
 # elliptic-curve = { version = "0.13.5", default-features = false, optional = true }

--- a/modules/utxo-core/src/core.rs
+++ b/modules/utxo-core/src/core.rs
@@ -4,10 +4,16 @@ use soroban_sdk::{
     BytesN, Env, IntoVal, Map, Symbol, Vec,
 };
 
+use moonlight_storage::{Store, UtxoStore};
+
+#[cfg(feature = "storage-drawer")]
+use moonlight_storage::{DrawerCache, DrawerStore};
+
 use soroban_sdk::symbol_short;
 
 #[cfg(not(feature = "no-bundle-events"))]
 use crate::events::BundleEvent;
+#[cfg(not(feature = "no-utxo-events"))]
 use crate::events::UtxoEvent;
 
 #[derive(Clone)]
@@ -73,22 +79,23 @@ pub trait UtxoHandlerTrait {
     /// If the UTXO is unspent, the stored balance is returned.
     /// If the UTXO is spent, 0 is returned.
     /// If no record exists for the UTXO (represented by –1), it is considered free to be created.
-    fn utxo_balance(e: Env, utxo: BytesN<65>) -> i128 {
-        match e
-            .storage()
-            .persistent()
-            .get::<_, UtxoState>(&UTXOCoreDataKey::UTXO(Self::hash_utxo_key(&e, &utxo)))
-        {
-            Some(UtxoState::Unspent(amount)) => amount,
-            Some(UtxoState::Spent) => 0,
-            None => -1,
-        }
+    fn utxo_balance(e: &Env, utxo: BytesN<65>) -> i128 {
+        // match e
+        //     .storage()
+        //     .persistent()
+        //     .get::<_, UtxoState>(&UTXOCoreDataKey::UTXO(Self::hash_utxo_key(&e, &utxo)))
+        // {
+        //     Some(UtxoState::Unspent(amount)) => amount,
+        //     Some(UtxoState::Spent) => 0,
+        //     None => -1,
+        // }
+        Store::utxo_balance(&e, &utxo)
     }
-    fn utxo_balances(e: Env, utxos: Vec<BytesN<65>>) -> Vec<i128> {
+    fn utxo_balances(e: &Env, utxos: Vec<BytesN<65>>) -> Vec<i128> {
         let mut balances: Vec<i128> = vec![&e];
 
         for u in utxos {
-            balances.push_back(Self::utxo_balance(e.clone(), u));
+            balances.push_back(Self::utxo_balance(&e, u));
         }
 
         balances
@@ -125,16 +132,79 @@ pub trait UtxoHandlerTrait {
 
         Self::auth(&e).require_auth_for_args(auth_args);
 
-        for spend_utxo in bundle.spend.iter() {
-            let unspent_balance = Self::spend(&e, spend_utxo.clone());
-            total_available_balance += unspent_balance;
+        #[cfg(feature = "storage-drawer")]
+        {
+            let mut cache = DrawerCache::new(e);
+
+            for spend_utxo in bundle.spend.iter() {
+                // Inline the verification and spend logic
+                let amount = match DrawerStore::utxo_balance_cached(e, &mut cache, &spend_utxo) {
+                    a if a > 0 => a,
+                    0 => panic_with_error!(e, Error::UTXOAlreadySpent),
+                    _ => panic_with_error!(e, Error::UTXODoesntExist),
+                };
+
+                DrawerStore::spend_cached(&e, &mut cache, &spend_utxo);
+                total_available_balance += amount;
+
+                #[cfg(not(feature = "no-utxo-events"))]
+                UtxoEvent {
+                    name: symbol_short!("utxo"),
+                    utxo: spend_utxo.clone(),
+                    action: symbol_short!("spend"),
+                    amount,
+                }
+                .publish(&e);
+            }
+
+            for (create_utxo, amount) in bundle.create.iter() {
+                // Inline the verification and create logic
+                if DrawerStore::utxo_balance_cached(e, &mut cache, &create_utxo) != -1 {
+                    panic_with_error!(e, Error::UTXOAlreadyExists);
+                }
+
+                assert_with_error!(&e, amount > 0, Error::InvalidCreateAmount);
+
+                DrawerStore::create_cached(&e, &mut cache, &create_utxo, amount);
+                total_available_balance -= amount;
+
+                #[cfg(not(feature = "no-utxo-events"))]
+                UtxoEvent {
+                    name: symbol_short!("utxo"),
+                    utxo: create_utxo.clone(),
+                    action: symbol_short!("create"),
+                    amount,
+                }
+                .publish(&e);
+            }
+
+            cache.commit(e);
         }
 
-        for (create_utxo, amount) in bundle.create.iter() {
-            Self::create(&e, amount, create_utxo.clone());
+        // Use regular storage when drawer is not enabled
+        #[cfg(not(feature = "storage-drawer"))]
+        {
+            for spend_utxo in bundle.spend.iter() {
+                let unspent_balance = Self::spend(&e, spend_utxo.clone());
+                total_available_balance += unspent_balance;
+            }
 
-            total_available_balance -= amount;
+            for (create_utxo, amount) in bundle.create.iter() {
+                Self::create(&e, amount, create_utxo.clone());
+                total_available_balance -= amount;
+            }
         }
+
+        // for spend_utxo in bundle.spend.iter() {
+        //     let unspent_balance = Self::spend(&e, spend_utxo.clone());
+        //     total_available_balance += unspent_balance;
+        // }
+
+        // for (create_utxo, amount) in bundle.create.iter() {
+        //     Self::create(&e, amount, create_utxo.clone());
+
+        //     total_available_balance -= amount;
+        // }
 
         assert_with_error!(
             &e,
@@ -169,7 +239,7 @@ pub trait UtxoHandlerTrait {
 
         assert_with_error!(&e, amount > 0, Error::InvalidCreateAmount);
 
-        Self::unchecked_create(e, amount, utxo);
+        Self::unchecked_create(e, amount, &utxo);
     }
 
     /// Spends the specified UTXO after verifying its state.
@@ -182,18 +252,22 @@ pub trait UtxoHandlerTrait {
     /// - Panics if signature verification fails.
     /// - Panics if the UTXO is already spent or does not exist.
     #[internal]
-    fn spend(e: &Env, utxo: BytesN<65>) -> i128 {
+    fn spend(e: &Env, utxo: &BytesN<65>) -> i128 {
         let amount = Self::verify_utxo_unspent(&e, utxo.clone());
         Self::unchecked_spend(&e, utxo.clone(), amount);
         amount
     }
 
     #[internal]
-    fn unchecked_create(e: &Env, amount: i128, utxo: BytesN<65>) {
-        let key = UTXOCoreDataKey::UTXO(Self::hash_utxo_key(&e, &utxo));
-        e.storage()
-            .persistent()
-            .set(&key, &UtxoState::Unspent(amount));
+    fn unchecked_create(e: &Env, amount: i128, utxo: &BytesN<65>) {
+        // let key = UTXOCoreDataKey::UTXO(Self::hash_utxo_key(&e, &utxo));
+        // e.storage()
+        //     .persistent()
+        //     .set(&key, &UtxoState::Unspent(amount));
+
+        Store::create(&e, &utxo, amount);
+
+        #[cfg(not(feature = "no-utxo-events"))]
         UtxoEvent {
             name: symbol_short!("utxo"),
             utxo,
@@ -205,8 +279,12 @@ pub trait UtxoHandlerTrait {
 
     #[internal]
     fn unchecked_spend(e: &Env, utxo: BytesN<65>, _amount: i128) {
-        let key = UTXOCoreDataKey::UTXO(Self::hash_utxo_key(&e, &utxo));
-        e.storage().persistent().set(&key, &UtxoState::Spent);
+        // let key = UTXOCoreDataKey::UTXO(Self::hash_utxo_key(&e, &utxo));
+        // e.storage().persistent().set(&key, &UtxoState::Spent);
+
+        Store::spend(&e, &utxo);
+
+        #[cfg(not(feature = "no-utxo-events"))]
         UtxoEvent {
             name: symbol_short!("utxo"),
             utxo,
@@ -228,23 +306,33 @@ pub trait UtxoHandlerTrait {
 
     #[internal]
     fn verify_utxo_not_exists(e: &Env, utxo: BytesN<65>) {
-        let key = UTXOCoreDataKey::UTXO(Self::hash_utxo_key(&e, &utxo));
+        // let key = UTXOCoreDataKey::UTXO(Self::hash_utxo_key(&e, &utxo));
 
-        assert_with_error!(
-            &e,
-            e.storage().persistent().get::<_, UtxoState>(&key).is_none(),
-            Error::UTXOAlreadyExists
-        );
+        // assert_with_error!(
+        //     &e,
+        //     e.storage().persistent().get::<_, UtxoState>(&key).is_none(),
+        //     Error::UTXOAlreadyExists
+        // );
+
+        if Store::utxo_balance(e, &utxo) != -1 {
+            panic_with_error!(e, Error::UTXOAlreadyExists);
+        }
     }
 
     #[internal]
     fn verify_utxo_unspent(e: &Env, utxo: BytesN<65>) -> i128 {
-        let key = UTXOCoreDataKey::UTXO(Self::hash_utxo_key(&e, &utxo));
+        // let key = UTXOCoreDataKey::UTXO(Self::hash_utxo_key(&e, &utxo));
 
-        match e.storage().persistent().get::<_, UtxoState>(&key) {
-            Some(UtxoState::Unspent(amount)) => amount,
-            Some(UtxoState::Spent) => panic_with_error!(&e, Error::UTXOAlreadySpent),
-            None => panic_with_error!(&e, Error::UTXODoesntExist),
+        // match e.storage().persistent().get::<_, UtxoState>(&key) {
+        //     Some(UtxoState::Unspent(amount)) => amount,
+        //     Some(UtxoState::Spent) => panic_with_error!(&e, Error::UTXOAlreadySpent),
+        //     None => panic_with_error!(&e, Error::UTXODoesntExist),
+        // }
+
+        match Store::utxo_balance(e, &utxo) {
+            a if a > 0 => a,
+            0 => panic_with_error!(e, Error::UTXOAlreadySpent),
+            _ => panic_with_error!(e, Error::UTXODoesntExist),
         }
     }
 }

--- a/modules/utxo-core/src/events.rs
+++ b/modules/utxo-core/src/events.rs
@@ -1,4 +1,8 @@
+#[cfg(not(feature = "no-bundle-events"))]
 use soroban_sdk::{contractevent, BytesN, Symbol, Vec};
+
+#[cfg(not(feature = "no-utxo-events"))]
+use soroban_sdk::{contractevent, BytesN, Symbol};
 
 #[cfg(not(feature = "no-bundle-events"))]
 #[contractevent(data_format = "vec")]

--- a/modules/utxo-core/src/testutils/contract.rs
+++ b/modules/utxo-core/src/testutils/contract.rs
@@ -58,7 +58,7 @@ impl UTXOModuleTestContract {
 
     pub fn burn(e: Env, utxos: Vec<BytesN<65>>) {
         for utxo in utxos {
-            Self::spend(&e, utxo);
+            Self::spend(&e, &utxo);
         }
     }
 }

--- a/modules/utxo-core/src/testutils/operation_bundle.rs
+++ b/modules/utxo-core/src/testutils/operation_bundle.rs
@@ -101,7 +101,6 @@ impl UTXOOperationBuilder {
         for (existing_utxo, conditions) in self.spend.iter() {
             if existing_utxo == utxo {
                 return AuthPayload {
-                    contract: self.channel_contract.clone(),
                     conditions: conditions.clone(),
                     live_until_ledger,
                 };
@@ -117,7 +116,11 @@ impl UTXOOperationBuilder {
         live_until_ledger: u32,
     ) -> Hash<32> {
         let payload = self.get_auth_payload_for_spend(utxo, live_until_ledger);
-        hash_payload(&e, &payload)
+        hash_payload(
+            &e,
+            &payload,
+            &self.channel_contract.clone().to_string().to_bytes(),
+        )
     }
 
     pub fn add_spend_signature(


### PR DESCRIPTION
This pull request introduces a new modular storage backend for UTXO data, allowing the system to switch between a simple and an optimized "drawer" storage implementation via feature flags. It also refactors the handling of authorization payloads to remove the contract address from the payload structure and instead pass it as a separate parameter when hashing, improving determinism and flexibility. Several internal APIs and test utilities are updated to accommodate these changes.

**Storage backend modularization:**

* Adds a new `moonlight-storage` crate with two storage backends: `SimpleStore` for straightforward storage and `DrawerStore` for optimized, cached storage; selection is controlled via feature flags (`storage-simple` or `storage-drawer`). [[1]](diffhunk://#diff-f7e36b2fb6a68745d371931af3a16649dadab677079c4487a00eb3dd95bab079R1-R20) [[2]](diffhunk://#diff-89077a2ba0d4f8a5369074b1b0e40a5d53b09f9d8da9763b6cfd7afbe80b9d6eR1-R76) [[3]](diffhunk://#diff-9a2bf49ad3d7b0a71071c9ca385f35790350c7b4b9d50ce76181eae1d8ad5443R1-R51) [[4]](diffhunk://#diff-8cba0a47e62486e7630ee078fafa84fa19955c07c29e6785b4078185a8e2df64R1-R309)
* Updates `Cargo.toml` dependencies and default features to enable the new storage module and set `storage-drawer` as the default. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R37) [[2]](diffhunk://#diff-537d208c678866911e6e1ca43b3c5bfb0f96987c48072013f0003584f64b973cR12-R15)

**Authorization payload and hashing refactor:**

* Removes the `contract` field from the `AuthPayload` struct and updates the `hash_payload` function to accept the contract address as a separate argument, requiring code changes wherever payloads are created or verified. [[1]](diffhunk://#diff-98042eb3893e1b76005533a92e426d82060710b252af3ac4eadc3f1147911462L101) [[2]](diffhunk://#diff-98042eb3893e1b76005533a92e426d82060710b252af3ac4eadc3f1147911462L123-R133) [[3]](diffhunk://#diff-cb556c85a49194d8134655207287780b3e66fa85295551bfb2ae4f41d7515f58L104-R104) [[4]](diffhunk://#diff-cb556c85a49194d8134655207287780b3e66fa85295551bfb2ae4f41d7515f58L125-R130) [[5]](diffhunk://#diff-418fc0959b9d57850a64ecdb06550dc40b5fe8fe2a0de7984c259763075071dfL145) [[6]](diffhunk://#diff-418fc0959b9d57850a64ecdb06550dc40b5fe8fe2a0de7984c259763075071dfL155) [[7]](diffhunk://#diff-418fc0959b9d57850a64ecdb06550dc40b5fe8fe2a0de7984c259763075071dfL172-R179)

**Feature flag and test configuration updates:**

* Adjusts feature flags in `contracts/privacy-channel/Cargo.toml` to support the new storage backend and disables certain UTXO and bundle events for test optimization.

**Code cleanup and deprecation:**

* Comments out unused or deprecated code related to condition extraction and review in `transact.rs`, reflecting changes in how conditions are processed.

(References: [[1]](diffhunk://#diff-f7e36b2fb6a68745d371931af3a16649dadab677079c4487a00eb3dd95bab079R1-R20) [[2]](diffhunk://#diff-89077a2ba0d4f8a5369074b1b0e40a5d53b09f9d8da9763b6cfd7afbe80b9d6eR1-R76) [[3]](diffhunk://#diff-9a2bf49ad3d7b0a71071c9ca385f35790350c7b4b9d50ce76181eae1d8ad5443R1-R51) [[4]](diffhunk://#diff-8cba0a47e62486e7630ee078fafa84fa19955c07c29e6785b4078185a8e2df64R1-R309) [[5]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R37) [[6]](diffhunk://#diff-537d208c678866911e6e1ca43b3c5bfb0f96987c48072013f0003584f64b973cR12-R15) [[7]](diffhunk://#diff-98042eb3893e1b76005533a92e426d82060710b252af3ac4eadc3f1147911462L101) [[8]](diffhunk://#diff-98042eb3893e1b76005533a92e426d82060710b252af3ac4eadc3f1147911462L123-R133) [[9]](diffhunk://#diff-cb556c85a49194d8134655207287780b3e66fa85295551bfb2ae4f41d7515f58L104-R104) [[10]](diffhunk://#diff-cb556c85a49194d8134655207287780b3e66fa85295551bfb2ae4f41d7515f58L125-R130) [[11]](diffhunk://#diff-418fc0959b9d57850a64ecdb06550dc40b5fe8fe2a0de7984c259763075071dfL145) [[12]](diffhunk://#diff-418fc0959b9d57850a64ecdb06550dc40b5fe8fe2a0de7984c259763075071dfL155) [[13]](diffhunk://#diff-418fc0959b9d57850a64ecdb06550dc40b5fe8fe2a0de7984c259763075071dfL172-R179) [[14]](diffhunk://#diff-cbeabd681c81136bcc369cf4508fca5f2901b30be3b68ebc6c2eae5686db6772L20-R20) [[15]](diffhunk://#diff-a15a21e13f55512aecd5d679e99e641578ad0488b6111a66041fdf92eab7986eL81-R109)