### PR TITLE
ci: add lifecycle E2E to PR workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,7 +29,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y pkg-config libdbus-1-dev libudev-dev
 
       - name: Install Stellar CLI
-        run: cargo install --locked stellar-cli
+        run: cargo install --locked --force stellar-cli
 
       - name: Build contracts
         run: stellar contract build

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -52,3 +52,11 @@ jobs:
       contracts_artifact: "contract-wasms"
     secrets:
       E2E_TRIGGER_TOKEN: ${{ secrets.E2E_TRIGGER_TOKEN }}
+
+  lifecycle:
+    needs: build
+    uses: Moonlight-Protocol/local-dev/.github/workflows/lifecycle-reusable.yml@main
+    with:
+      contracts_artifact: "contract-wasms"
+    secrets:
+      E2E_TRIGGER_TOKEN: ${{ secrets.E2E_TRIGGER_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds a `lifecycle` job to the PR workflow, running in parallel with the existing `e2e` job
- Both depend on the `build` job's `contract-wasms` artifact
- The lifecycle test deploys contracts programmatically and validates the full protocol lifecycle

## Dependencies
- Moonlight-Protocol/local-dev#19 must be merged first (provides the reusable workflow)

## Test plan
- [ ] Lifecycle job runs successfully once the local-dev PR lands