### PR TITLE
fix: upgrade ed25519-dalek to v2 (CVE-2022-50237)

### DIFF
--- a/modules/helpers/Cargo.toml
+++ b/modules/helpers/Cargo.toml
@@ -15,8 +15,8 @@ doctest = false
 soroban-sdk = {workspace = true}
 stellar-strkey = { version = "0.0.13" }
 
-ed25519-dalek = { version = "1.0.1" , optional =    true}
-rand = { version = "0.7.3" , optional = true}
+ed25519-dalek = { version = "2", optional = true }
+rand = { version = "0.8", optional = true }
 p256 = { version = "0.13.2", default-features = false, features = ["ecdsa", "arithmetic"], optional = true}
 elliptic-curve = { version = "0.13.5", default-features = false, optional = true }
 rand_core = { version = "0.6",optional = true }
@@ -26,5 +26,5 @@ soroban-sdk = { workspace = true, features = ["testutils"] }
 p256 = { version = "0.13.2", default-features = false, features = ["ecdsa", "arithmetic"] }
 rand_core = { version = "0.6"}
 elliptic-curve = { version = "0.13.5", default-features = false}
-rand = { version = "0.7.3" }
+rand = { version = "0.8" }
 moonlight-helpers = { workspace = true, features = ["testutils"] }

--- a/modules/helpers/src/testutils/keys.rs
+++ b/modules/helpers/src/testutils/keys.rs
@@ -1,4 +1,4 @@
-use ed25519_dalek::{Keypair as NativeKeypair, Signer as NativeSigner};
+use ed25519_dalek::{Signer as NativeSigner, SigningKey as NativeSigningKey};
 use p256::{
     ecdsa::{
         signature::hazmat::PrehashSigner, Signature as P256Signature, SigningKey as P256SigningKey,
@@ -21,51 +21,41 @@ pub struct AccountEd25519Signature {
 
 pub struct Ed25519Account {
     pub public_key: BytesN<32>,
-    pub keypair: NativeKeypair,
+    pub signing_key: NativeSigningKey,
     pub address: Address,
 }
 
 impl Ed25519Account {
-    pub fn from_keys(e: &Env, public: &[u8; 32], secret: &[u8; 32]) -> Ed25519Account {
-        let public =
-            ed25519_dalek::PublicKey::from_bytes(public).expect("32 bytes, valid ed25519 pk");
-        let secret =
-            ed25519_dalek::SecretKey::from_bytes(secret).expect("64 bytes, within curve order");
-
-        let keypair = NativeKeypair {
-            secret,
-            public: public.try_into().expect("32 bytes, valid ed25519 pk"),
-        };
-
-        Self::from_keypair(e, keypair)
+    pub fn from_keys(e: &Env, _public: &[u8; 32], secret: &[u8; 32]) -> Ed25519Account {
+        let signing_key = NativeSigningKey::from_bytes(secret);
+        Self::from_signing_key(e, signing_key)
     }
 
     pub fn generate(e: &Env) -> Ed25519Account {
-        let mut csprng = OsRng {};
-
-        let keypair = NativeKeypair::generate(&mut csprng);
-
-        Self::from_keypair(e, keypair)
+        let mut csprng = OsRng;
+        let signing_key = NativeSigningKey::generate(&mut csprng);
+        Self::from_signing_key(e, signing_key)
     }
 
-    pub fn from_keypair(e: &Env, keypair: NativeKeypair) -> Ed25519Account {
+    pub fn from_signing_key(e: &Env, signing_key: NativeSigningKey) -> Ed25519Account {
+        let verifying_key = signing_key.verifying_key();
         let public_key_str =
-            Strkey::PublicKeyEd25519(ed25519::PublicKey(keypair.public.to_bytes()));
+            Strkey::PublicKeyEd25519(ed25519::PublicKey(verifying_key.to_bytes()));
 
         let address_bytes = Bytes::from_slice(&e, public_key_str.to_string().as_bytes());
         let address = Address::from_string_bytes(&address_bytes);
 
-        let public_key = BytesN::<32>::from_array(&e, &keypair.public.to_bytes());
+        let public_key = BytesN::<32>::from_array(&e, &verifying_key.to_bytes());
 
         Ed25519Account {
             public_key,
-            keypair,
+            signing_key,
             address,
         }
     }
 
     pub fn sign(&self, e: &Env, msg: Hash<32>) -> BytesN<64> {
-        let signed_payload = self.keypair.sign(msg.to_array().as_slice()).to_bytes();
+        let signed_payload = self.signing_key.sign(msg.to_array().as_slice()).to_bytes();
 
         BytesN::from_array(&e, &signed_payload)
     }
@@ -74,7 +64,7 @@ impl Ed25519Account {
         let raw_signature = self.sign(e, msg);
 
         AccountEd25519Signature {
-            public_key: BytesN::<32>::try_from_val(e, &self.keypair.public.to_bytes()).unwrap(),
+            public_key: BytesN::<32>::try_from_val(e, &self.signing_key.verifying_key().to_bytes()).unwrap(),
             signature: BytesN::<64>::try_from_val(e, &raw_signature).unwrap(),
         }
     }


### PR DESCRIPTION
## Summary
- Upgrades `ed25519-dalek` from 1.0.1 to 2.x, resolving [Dependabot alert #1](https://github.com/Moonlight-Protocol/soroban-core/security/dependabot/1) (CVE-2022-50237)
- Migrates from deprecated `Keypair` API to `SigningKey` which derives the public key internally, eliminating the double public key signing oracle attack vector
- Bumps `rand` from 0.7 to 0.8 for compatibility

## Notes
- `ed25519-dalek` is only used in the `testutils` feature (test-only, optional) — no production impact
- All existing tests pass

## Test plan
- [x] `cargo check --features testutils -p moonlight-helpers` compiles cleanly
- [x] `cargo test` — all 7 tests pass
- [x] CI e2e workflow