### PR TITLE
docs: audit-kickoff package for Soroban Audit Bank intake

### DIFF
--- a/contracts/arch.md
+++ b/contracts/arch.md
@@ -1,0 +1,411 @@
+# Soroban Core — Contract Architecture
+
+This document describes the in-scope smart contracts in `Moonlight-Protocol/soroban-core` for security audit purposes. It targets readers who have not seen the codebase before and need to build a working model of the protocol from the contract perspective.
+
+The audit scope is exactly the two contracts in `contracts/`:
+
+- `contracts/channel-auth/` — the **Channel Auth** contract (referred to as *Quorum Auth* in the README).
+- `contracts/privacy-channel/` — the **Privacy Channel** contract.
+
+The supporting modules in `modules/` (`utxo-core`, `auth`, `primitives`, `storage`, `helpers`) are linked in as `rlib` workspace dependencies and ship as part of the contract WASMs. They are in scope insofar as the contracts depend on them, but they do not deploy as standalone contracts.
+
+The `contracts/token/` directory is a test-only token used by `privacy-channel` integration tests; it is **not** in audit scope and is not deployed.
+
+Off-chain components — provider platform, browser wallet, council-console, network-dashboard, the moonlight-sdk, and the local-dev orchestration — are out of scope.
+
+---
+
+## 1. Protocol overview from the contract perspective
+
+Moonlight is a privacy-preserving asset channel built on Soroban. At the contract layer the protocol consists of two compositional pieces:
+
+1. **Privacy Channel** holds a single Stellar asset (an SAC — Stellar Asset Contract — address) and tracks its supply across an internal UTXO set. Users move asset balances into the channel via `ExtDeposit`, transfer privately within the channel via `Spend`/`Create`, and exit via `ExtWithdraw`. All of this happens through a single unified entry point: `transact(op: ChannelOperation)`.
+
+2. **Channel Auth** is a separate contract that implements Soroban's `CustomAccountInterface`. The Privacy Channel stores a Channel Auth contract address as its authorization principal. Whenever the Privacy Channel needs to authorize an internal UTXO operation, it calls `require_auth_for_args` on this Channel Auth address, which in turn invokes `__check_auth` on the Channel Auth contract. Channel Auth verifies (a) at least one registered Privacy Provider has signed the bundle, and (b) every spending UTXO owner has signed the conditions they intend to authorize.
+
+A single Channel Auth contract may govern multiple Privacy Channel contracts (the README refers to this as a "quorum"). The Channel Auth has its own admin (typically a Stellar account with native multisig representing the Moonlight Security Council) who can add/remove providers, transfer admin rights, and upgrade either contract.
+
+### 1.1 Composition at runtime
+
+A typical end-to-end flow when a user transfers privately:
+
+1. User assembles a `ChannelOperation` off-chain (with the help of moonlight-sdk): a list of UTXOs to spend, UTXOs to create, deposits and withdrawals.
+2. Each UTXO owner produces a P256 (secp256r1) ECDSA signature over a hash of the conditions they authorize, plus a `live_until_ledger`.
+3. A registered Privacy Provider produces a Stellar-native auth-entry signature (Ed25519) over the canonical Soroban authorization payload for the `transact` invocation.
+4. The provider submits the transaction. The Privacy Channel's `transact` function:
+   - validates external-operation structure (no duplicate addresses; no condition conflicts);
+   - delegates UTXO-set mutation to `process_bundle` (from `moonlight-utxo-core::core::UtxoHandlerTrait`), which calls `auth.require_auth_for_args(...)` against Channel Auth;
+   - Soroban host invokes `Channel Auth::__check_auth`, which verifies the provider Ed25519 signature and every per-UTXO P256 signature;
+   - `process_bundle` applies spends and creates atomically, asserting balance equality;
+   - `transact` then dispatches `ExtDeposit` and `ExtWithdraw` operations through the asset SAC, adjusting `Supply` accordingly.
+
+Any failure at any step reverts the entire transaction.
+
+---
+
+## 2. Channel Auth (`contracts/channel-auth/`)
+
+### 2.1 Responsibilities
+
+- Maintain the registered set of Privacy Providers authorized to sign bundles.
+- Maintain the admin address with rights to mutate the provider set, transfer admin, and upgrade contracts.
+- Implement `CustomAccountInterface` so that other contracts (specifically, Privacy Channel instances) can use a Channel Auth contract address as their authorization principal.
+- Verify provider Ed25519 signatures and per-UTXO P256 signatures on every bundle.
+
+### 2.2 Public interface
+
+Source of truth: `contracts/channel-auth/src/contract.rs`.
+
+| Function | Caller | Args | Returns | Purpose |
+|---|---|---|---|---|
+| `__constructor(admin)` | Soroban runtime (deploy time) | `admin: Address` | — | Sets admin, emits `ContractInitialized`. |
+| `add_provider(provider)` | admin | `provider: Address` | — | Registers a provider. Emits `ProviderAdded`. Panics if already registered. |
+| `remove_provider(provider)` | admin | `provider: Address` | — | Deregisters a provider. Emits `ProviderRemoved`. Panics if not registered. |
+| `is_provider(provider)` | anyone | `provider: Address` | `bool` | Read-only membership query. |
+| `set_admin(new_admin)` | admin | `new_admin: Address` | — | From `admin-sep::Administratable`. Transfers admin role. |
+| `admin()` | anyone | — | `Address` | From `admin-sep::Administratable`. Read current admin. |
+| `upgrade(wasm_hash)` | admin | `wasm_hash: BytesN<32>` | — | From `admin-sep::Upgradable`. Replaces contract WASM. |
+| `__check_auth(payload, signatures, contexts)` | Soroban host | `payload: Hash<32>`, `signatures: Signatures`, `contexts: Vec<Context>` | `Result<(), Error>` | Auth entry point invoked by Soroban when this contract is named as an authorization principal. |
+
+The `Administratable` and `Upgradable` traits are pulled from the AhaLabs fork of `admin-sep` (workspace dep, rev `bf195f4`). They provide standard admin-gated patterns and require admin auth at the entry point.
+
+### 2.3 Persistent state (instance storage)
+
+Keys (all under `e.storage().instance()`):
+
+- `Admin` — `Address`. Set in constructor; mutated by `set_admin`. (Encoded by admin-sep, not by this contract directly.)
+- `ProviderDataKey::AuthorizedProvider(addr)` — `()`. One entry per registered provider. Membership is checked via `.get(...).is_some()`.
+
+Storage is **instance** (lives with the contract, has the contract's TTL) — not persistent. This means provider set lookups are cheap (single instance read) but the provider set must fit in a single instance entry's encoded size.
+
+There is no nonce, no per-account replay state, and no rate-limiting state in Channel Auth. Replay protection comes entirely from Soroban's authorization-entry nonce (managed by the host) and from per-signature `live_until_ledger` expiry checks.
+
+### 2.4 Events emitted
+
+- `contract_initialized` — `{ admin: Address }`. Topic-formatted via `#[contractevent]`.
+- `provider_added` — `{ provider: Address }`.
+- `provider_removed` — `{ provider: Address }`.
+
+There is **no event emitted on `set_admin` or `upgrade`** by this contract directly. Whatever auditing trail exists for those actions comes from the underlying `admin-sep` traits and the Soroban transaction record.
+
+### 2.5 Auth flow detail
+
+On every `transact` against a Privacy Channel governed by a Channel Auth instance, Soroban invokes:
+
+```
+Channel Auth::__check_auth(payload, signatures, contexts)
+```
+
+with:
+
+- `payload` = the canonical Soroban authorization-entry hash for the `transact(...)` invocation (network ID, nonce, expiration ledger, root invocation).
+- `signatures: Signatures` = `Map<SignerKey, (Signature, valid_until_ledger: u32)>`. Provided by the transaction submitter.
+- `contexts: Vec<Context>` = the tree of `require_auth_for_args` sites along this auth chain.
+
+The implementation runs two checks in sequence (`contracts/channel-auth/src/contract.rs:78-87`):
+
+**(a) `require_provider(payload, signatures)`** — defined in `moonlight-auth::core::ProviderAuthorizable`:
+
+- Iterates `signatures.0.keys()`.
+- For each `SignerKey::Provider(pk32)`: convert pk32 → G… address; assert it is a registered provider; assert the signature has not expired (`valid_until_ledger >= current_ledger_sequence`); verify the Ed25519 signature against `payload`.
+- Counts valid provider signatures into `provider_quorum`.
+- Errors with `ProviderThresholdNotMet` unless `provider_quorum >= PROVIDER_THRESHOLD`. **`PROVIDER_THRESHOLD` is hardcoded to 1.**
+
+**(b) `handle_utxo_auth(signatures, contexts)`** — defined in `moonlight-auth::core::UtxoAuthorizable`:
+
+- For each context in `contexts`:
+  - Reject if not a `Context::Contract` (e.g. `Context::CreateContractHostFn`) — error `UnexpectedContext`.
+  - If the contract context has zero `args`, return `Ok(())` without further checks (interpreted as "no auth requirements for this call site").
+  - Otherwise, parse `args[0]` as `AuthRequirements` (`Map<SignerKey, Vec<Condition>>`).
+  - For each entry in the map whose key is `SignerKey::P256(...)`:
+    - Look up the corresponding `(Signature, valid_until_ledger)` in `signatures`.
+    - Reject expired signatures (`SignatureExpired`).
+    - Recompute the per-UTXO auth payload as `hash_payload(AuthPayload { conditions, live_until_ledger }, caller_contract_address_bytes)` (see `moonlight-primitives::hash_payload`).
+    - Verify the secp256r1 signature against this hash.
+  - Map entries whose key is not `SignerKey::P256(...)` are silently skipped (with `continue`). In production this never matters because `calculate_auth_requirements` only constructs P256 entries.
+
+Both checks must succeed for `__check_auth` to return `Ok(())`. The Soroban host treats anything else as failed auth and aborts the transaction.
+
+### 2.6 Trust assumptions for Channel Auth
+
+| Principal | Trust | Capabilities |
+|---|---|---|
+| Admin | Highest | Add/remove providers; set new admin; upgrade contract WASM. Compromise of the admin key compromises the entire auth surface and any Privacy Channels governed by this Channel Auth. |
+| Provider | Bundle-level | Can authorize any well-formed bundle by producing a valid Ed25519 signature over its auth payload. Cannot mint, burn, or move UTXOs they do not co-authorize via P256 signatures. |
+| UTXO owner (P256) | Per-UTXO | Can authorize spending of UTXOs whose public key matches their P256 secret. Cannot bypass the provider check. |
+| Soroban host | Implicit | Signature verification primitives (`secp256r1_verify`, `ed25519_verify`) are trusted to panic on invalid signatures. The verify wrappers in `modules/auth/src/core.rs` rely on this panic-on-failure semantic and do not propagate a failure result of their own. |
+
+---
+
+## 3. Privacy Channel (`contracts/privacy-channel/`)
+
+### 3.1 Responsibilities
+
+- Hold a balance of a single Stellar asset (the asset address is set at construction time and never overwritten in any code path).
+- Maintain a UTXO set keyed by 65-byte SEC1-uncompressed P256 public keys, persisted via the storage backend selected at compile time.
+- Track the channel's total `Supply` — the sum of all unspent UTXO amounts that originated from `ExtDeposit` minus all `ExtWithdraw` amounts.
+- Expose a single mutating entry point — `transact(op: ChannelOperation)` — that atomically processes any combination of spends, creates, deposits, and withdrawals.
+- Delegate authorization to its configured Channel Auth contract.
+
+### 3.2 Public interface
+
+Source of truth: `contracts/privacy-channel/src/contract.rs`.
+
+| Function | Caller | Args | Returns | Purpose |
+|---|---|---|---|---|
+| `__constructor(admin, auth_contract, asset)` | Soroban runtime | `admin: Address`, `auth_contract: Address`, `asset: Address` | — | Sets admin, requires admin auth, sets the auth contract address, writes the asset address. |
+| `asset()` | anyone | — | `Address` | Returns the asset SAC address. |
+| `supply()` | anyone | — | `i128` | Returns current channel supply. |
+| `transact(op)` | anyone (with valid auth) | `op: ChannelOperation` | — | Unified bundle-processing entry point. |
+| `auth()` | anyone | — | `Address` | From `UtxoHandlerTrait`. Returns Channel Auth contract address. |
+| `set_auth(new_auth)` | host invocations only | `new_auth: Address` | — | From `UtxoHandlerTrait`. Marked `#[internal]`; not directly invokable by external callers. |
+| `utxo_balance(utxo)` | anyone | `utxo: BytesN<65>` | `i128` | Reads UTXO state. Returns positive amount if unspent, `0` if spent, `-1` if no record exists. |
+| `utxo_balances(utxos)` | anyone | `utxos: Vec<BytesN<65>>` | `Vec<i128>` | Batch wrapper around `utxo_balance`. |
+| `set_admin(new_admin)` | admin | `new_admin: Address` | — | From `admin-sep::Administratable`. |
+| `admin()` | anyone | — | `Address` | From `admin-sep::Administratable`. |
+| `upgrade(wasm_hash)` | admin | `wasm_hash: BytesN<32>` | — | From `admin-sep::Upgradable`. |
+
+`ChannelOperation` is defined in `contracts/privacy-channel/src/transact.rs`:
+
+```rust
+pub struct ChannelOperation {
+    pub spend:    Vec<(BytesN<65>, Vec<Condition>)>,
+    pub create:   Vec<(BytesN<65>, i128)>,
+    pub deposit:  Vec<(Address, i128, Vec<Condition>)>,
+    pub withdraw: Vec<(Address, i128, Vec<Condition>)>,
+}
+```
+
+`Condition` is defined in `modules/primitives/src/lib.rs`:
+
+```rust
+pub enum Condition {
+    Create(BytesN<65>, i128),                       // expected outgoing UTXO
+    ExtDeposit(Address, i128),                      // expected deposit from address
+    ExtWithdraw(Address, i128),                     // expected withdrawal to address
+    ExtIntegration(Address, Vec<BytesN<65>>, i128), // adapter address, keys, amount
+}
+```
+
+The four operation types in the README — Create, Spend, ExtDeposit, ExtWithdraw — correspond exactly to the four fields above. `ExtIntegration` is a condition variant (not an operation type) used to express adapter-mediated cross-flows, but the contracts themselves do not currently consume this variant during execution; `execute_external_operations` only iterates `deposit` and `withdraw`.
+
+### 3.3 Persistent state
+
+**Instance storage** (lifetime tied to contract):
+
+- `PrivacyChannelDataKey::Asset` — `Address`. Written exactly once in `__constructor` via `write_asset_unchecked` and never touched again. There is no `set_asset` function.
+- `PrivacyChannelDataKey::Supply` — `i128`. Mutated by `increase_supply` / `decrease_supply` (in `treasury.rs`) on `ExtDeposit` / `ExtWithdraw`.
+- `STORAGE_KEY_UTXO_AUTH` (symbol `"UTXO_AUTH"`) — `Address`. Written in `__constructor` via `set_auth`. There is no exposed external mutator.
+- `Admin` — `Address`, encoded by admin-sep.
+
+**Persistent storage** (per-UTXO, lives independently of contract instance TTL):
+
+The active backend is selected at compile time via mutually exclusive cargo features `storage-simple` and `storage-drawer`. The default selected by `moonlight-utxo-core` is `storage-drawer`.
+
+- **`storage-simple`** (`modules/storage/src/simple.rs`): each UTXO is a separate persistent entry keyed by `UTXOCoreDataKey::UTXO(sha256(pk65))`, value `UtxoState::Unspent(i128) | Spent`.
+- **`storage-drawer`** (`modules/storage/src/drawer.rs`): each UTXO is a `UtxoMeta { amount, drawer_id, slot_idx }` entry plus a bit in a 1024-slot bitmap stored at `DrawerDataKey::Drawer(DrawerKey { id })`. There is also a `DrawerDataKey::State` entry that tracks the current allocation pointer (`current_drawer: u32`, `next_slot: u32`). The drawer backend is intended to amortize storage cost across many UTXOs by packing the spent/unspent flag into a shared bitmap.
+
+UTXO keys are hashed (sha256) before being stored, so storage uses 32-byte keys instead of 65-byte ones. This is a cost optimization; collision resistance comes from sha256.
+
+The Privacy Channel contract is configured to consume `moonlight-utxo-core` with the `no-utxo-events` and `no-bundle-events` cargo features enabled (see `contracts/privacy-channel/Cargo.toml`). This **suppresses** the per-UTXO and bundle-level event emissions that `moonlight-utxo-core` would otherwise publish. **The Privacy Channel itself does not emit any events from `transact`.** The only on-chain event trail for a transact invocation comes from the underlying SAC `transfer` calls during `ExtDeposit` and `ExtWithdraw`. Bundles that consist purely of internal `spend` and `create` operations leave **no Soroban event behind** — their existence is visible only in transaction footprints, fees, and the resulting UTXO storage state.
+
+### 3.4 Events emitted
+
+None directly from `Privacy Channel`. Indirect events:
+
+- SAC `transfer` events on `ExtDeposit` (asset → channel) and `ExtWithdraw` (channel → asset).
+- `ContractInitialized`, `ProviderAdded`, `ProviderRemoved` from the Channel Auth contract that governs this channel (separate contract).
+
+### 3.5 Auth flow detail
+
+`transact` runs three phases:
+
+**(a) `pre_process_channel_operation`** — `contracts/privacy-channel/src/transact.rs:39`:
+
+- `op_has_no_conflicting_conditions(&e, &op)` — flatten the conditions across spend/deposit/withdraw and check pairwise `Condition::conflicts_with`. Conflicts include:
+  - Two `Create(utxo, a)` and `Create(utxo, b)` with `a != b` (same target, different amount).
+  - Two `ExtDeposit(addr, a)` / `ExtDeposit(addr, b)` with `a != b`. (Same for `ExtWithdraw`.)
+  - Two `ExtIntegration` entries that overlap UTXOs across different adapters, or differ in amount/UTXO-set within the same adapter.
+- Sum `total_deposit` and `total_withdraw` over the deposit/withdraw lists, with `checked_add` overflow detection (errors `AmountOverflow`).
+- `verify_external_operations`:
+  - No duplicate addresses in `deposit` or `withdraw` (errors `RepeatedAccountForDeposit` / `RepeatedAccountForWithdraw`).
+  - If an address appears in *both* deposit and withdraw, the two condition sequences must be byte-equal under XDR encoding (errors `ConflictingConditionsForAccount`). This is stricter than the conflict-free check above and is the only path through which an address may legitimately appear on both sides.
+- Build `AuthRequirements` from the `spend` list via `calculate_auth_requirements`: one P256 entry per (utxo, conditions) pair.
+- Build `InternalBundle { spend, create, req }` and return it along with the deposit/withdraw totals.
+
+**(b) `Self::process_bundle(env, bundle, total_deposit, total_withdraw)`** — `modules/utxo-core/src/core.rs:96-208`:
+
+- Assert no duplicate UTXO keys in `bundle.spend` (errors `RepeatedSpendUTXO`) or `bundle.create` (errors `RepeatedCreateUTXO`).
+- Construct `auth_args = vec![&e]` if `bundle.req.0.is_empty()` (no spends), else `vec![&e, bundle.req.into_val(e)]`.
+- Call `Self::auth().require_auth_for_args(auth_args)`. This is the line that triggers the Soroban host to invoke `Channel Auth::__check_auth`.
+- For each `spend_utxo` in `bundle.spend`: read the UTXO's current balance, panic if 0 (`UTXOAlreadySpent`) or -1 (`UTXODoesntExist`), mark spent, accumulate amount to `total_available_balance`.
+- For each `(create_utxo, amount)` in `bundle.create`: assert the UTXO does not yet exist (panic `UTXOAlreadyExists` if it does), assert `amount > 0` (panic `InvalidCreateAmount`), allocate, deduct from `total_available_balance`.
+- Final invariant check: `total_available_balance == expected_outgoing` (the `total_withdraw` argument). Panic `UnbalancedBundle` if not.
+- Bundle and per-UTXO events would be published here, but are suppressed by the `no-bundle-events` and `no-utxo-events` features.
+
+**(c) `execute_external_operations(deposit, withdraw)`** — `contracts/privacy-channel/src/transact.rs:112`:
+
+- For each deposit `(from, amount, conditions)`:
+  - `from.require_auth_for_args(vec![&e, conditions.into_val(&e)])` — requires the depositor to authorize this exact set of conditions.
+  - `asset_client.transfer(&from, &channel, &amount)` — pulls funds in.
+  - `increase_supply(&e, amount)`.
+- For each withdrawal `(to, amount, _conditions)`:
+  - `e.authorize_as_current_contract(...)` — the channel contract self-authorizes the outbound transfer.
+  - `asset_client.transfer(&channel, &to, &amount)`.
+  - `decrease_supply(&e, amount)`.
+
+If any phase panics, the entire transaction reverts.
+
+### 3.6 Trust assumptions for Privacy Channel
+
+| Principal | Trust | Capabilities |
+|---|---|---|
+| Admin (own admin, distinct from Channel Auth admin in general) | High | Transfer admin, upgrade WASM. Compromise allows replacing contract logic on next upgrade. |
+| Channel Auth contract | High | Indirect — every UTXO operation flows through this contract's `__check_auth`. Compromise of the Channel Auth's admin or providers compromises this channel. |
+| Providers (registered in Channel Auth) | Bundle-level | Authorize entire bundles (threshold 1). Cannot mint UTXOs or move UTXOs whose P256 owners did not co-sign. |
+| UTXO owners (P256) | Per-UTXO | Authorize spending of their own UTXOs subject to specific conditions. |
+| Depositors (Stellar G-accounts) | Per-deposit | Authorize moving asset balance into the channel under specific receive-side conditions. |
+| Withdraw recipients | None required | The contract self-authorizes outbound transfers; recipients do not sign. This means anyone with the right combination of signatures can name anyone as a withdrawal recipient — recipient consent is not a contract concern. |
+| Asset SAC | High | Trusted to enforce its own transfer semantics. The Privacy Channel does not validate the asset contract beyond storing its address; it assumes a well-behaved SAC. |
+
+---
+
+## 4. Invariants
+
+The contracts are intended to uphold each of the following invariants. Where they map to specific code locations, those are noted.
+
+### 4.1 Channel Auth invariants
+
+- **CA-1 (admin gating).** Provider mutations (`add_provider`, `remove_provider`), admin transfer (`set_admin`), and contract upgrade (`upgrade`) require admin auth. *Enforced by `Self::require_admin(e)` at the top of each path and the `admin-sep` traits.*
+- **CA-2 (provider threshold).** No `__check_auth` succeeds unless at least one signature in `signatures` is `(SignerKey::Provider(...), Signature::Ed25519(...))` from a currently registered provider, valid against the Soroban auth-entry payload, with an unexpired `valid_until_ledger`. *Enforced by `require_provider`.*
+- **CA-3 (no expired sigs).** `__check_auth` rejects any signature whose `valid_until_ledger < current_ledger_sequence`. *Enforced in both `require_provider` and `handle_utxo_auth`.*
+- **CA-4 (P256 coverage).** For every P256 signer present in the per-context `AuthRequirements` map, there must be a corresponding valid P256 signature in `signatures` over `hash_payload(conditions, live_until_ledger, contract_address_bytes)`. Missing entries error `MissingSignature`. *Enforced in `handle_utxo_auth`.*
+- **CA-5 (context-shape).** Only `Context::Contract` contexts are accepted. Any other context variant errors `UnexpectedContext`. *Enforced in `handle_utxo_auth`.*
+- **CA-6 (signature/key match).** Each verified signer/signature pair must have matching curve types: P256 signer ↔ P256 signature, Provider/Ed25519 signer ↔ Ed25519 signature. Mismatches error `InvalidSignatureFormat`. *Enforced by `verify_signature` in `modules/auth/src/core.rs`.*
+- **CA-7 (event coverage for governance).** Every change to the provider set emits the corresponding event (`ProviderAdded` / `ProviderRemoved`). *Enforced in `add_provider` / `remove_provider`.*
+
+Known invariant gap in CA-7: `set_admin` and `upgrade` do not emit explicit events from this contract; their audit trail relies on whatever admin-sep emits and on the Stellar transaction record itself. This is documented in §6.
+
+### 4.2 Privacy Channel invariants
+
+- **PC-1 (immutable asset binding).** Once set in the constructor, `Asset` is never overwritten by any code path. The only writer is `write_asset_unchecked`, which is only called from `__constructor`. There is no setter exposed externally. *Enforced by code structure.*
+- **PC-2 (immutable auth binding).** The auth-contract address (`STORAGE_KEY_UTXO_AUTH`) is set in the constructor and has no externally callable setter. The internal `set_auth` is `#[internal]` and is therefore not in the contract's external interface. *Enforced by code structure.*
+- **PC-3 (supply ↔ external flow).** `Supply` increases only via `increase_supply` (called once per `ExtDeposit` in `execute_external_operations`) and decreases only via `decrease_supply` (called once per `ExtWithdraw`). It does not change in response to internal `Spend` / `Create`. *Enforced by `transact.rs:121-148`.*
+- **PC-4 (bundle balance).** `process_bundle` enforces `total_available_balance == expected_outgoing` at the end of each bundle. Net effect: `sum_spent + total_deposit == sum_created + total_withdraw`. *Enforced by `core.rs:189-193`.*
+- **PC-5 (UTXO uniqueness — create).** No UTXO key may be created if any prior record exists for it (whether unspent or spent). *Enforced by `verify_utxo_not_exists` (simple) or `is_bit_set` check + meta lookup (drawer).*
+- **PC-6 (UTXO uniqueness — spend).** No UTXO may be spent twice, nor may a UTXO that has never been created be spent. *Enforced by `verify_utxo_unspent` (simple) or `is_bit_set` check (drawer).*
+- **PC-7 (no in-bundle duplicates).** `bundle.spend` and `bundle.create` lists must each have unique UTXO keys. *Enforced by `no_duplicate_keys` in `process_bundle`.*
+- **PC-8 (positive create amounts).** Every newly created UTXO has `amount > 0`. *Enforced by `assert_with_error!(amount > 0)` in both create paths.*
+- **PC-9 (no duplicate addresses externally).** `op.deposit` and `op.withdraw` each have unique addresses. *Enforced by `verify_external_operations`.*
+- **PC-10 (cross-side condition equality).** If an address appears in *both* `deposit` and `withdraw`, the two condition sequences must be XDR-equal. *Enforced by `verify_external_operations`.*
+- **PC-11 (no condition conflicts).** Across the flat list of conditions in spend ∪ deposit ∪ withdraw, no pair conflicts under `Condition::conflicts_with`. *Enforced by `op_has_no_conflicting_conditions`.*
+- **PC-12 (overflow safety on totals).** Summing `total_deposit` and `total_withdraw` uses `checked_add`; an overflow errors `AmountOverflow`. The internal supply uses `checked_add` / `checked_sub` via `treasury.rs`. *Enforced by `pre_process_channel_operation` and `treasury.rs`.*
+- **PC-13 (depositor consent).** Every `ExtDeposit` requires `from.require_auth_for_args(vec![&e, conditions])`. The depositor cannot have funds pulled from their account without explicitly signing for the exact condition list. *Enforced by `transact.rs:122`.*
+- **PC-14 (withdrawal authorization).** All withdrawals are authorized inside the bundle's `__check_auth` call (every spent UTXO's owner signed conditions covering the withdrawal). The contract itself self-authorizes the SAC transfer call via `authorize_as_current_contract`, which is sound only if `__check_auth` has already validated the bundle. *Enforced by ordering in `transact()` — pre_process and process_bundle precede `execute_external_operations`.*
+- **PC-15 (atomicity).** The three phases (`pre_process`, `process_bundle`, `execute_external_operations`) execute within a single Soroban transaction; any panic reverts everything. *Implicit from Soroban semantics.*
+
+### 4.3 Cross-contract invariants
+
+- **X-1.** A Privacy Channel's `auth` address is set at construction and used for every bundle. Replacing the underlying Channel Auth requires replacing this address, which is not exposed externally and would require a contract `upgrade` to a new WASM that re-runs `set_auth`. *Enforced by code structure.*
+- **X-2.** Multiple Privacy Channels may share the same Channel Auth instance. Compromise of a single Channel Auth admin therefore compromises every channel that names it. *Property, not a code-enforced invariant.*
+
+---
+
+## 5. Trust boundaries
+
+The following diagram maps where data crosses trust boundaries and what must be verified at each crossing.
+
+```
++--------------+        +-----------------+        +----------------+
+|   User /     |        | Provider Plat-  |        |   Stellar /    |
+|   Wallet     | ──→    | form (off-chain)| ──→    |   Soroban      |
++--------------+        +-----------------+        +----------------+
+        │                      │                          │
+        │ P256 sigs            │ Ed25519 sig              │ host crypto
+        │ (UTXO conditions)    │ (bundle approval)        │ panics on bad sig
+        │                      │                          │
+        ▼                      ▼                          ▼
++--------------------------------------------------------------------+
+|                       Channel Auth contract                        |
+|                                                                    |
+|  __check_auth:                                                     |
+|    1. require_provider — Ed25519 verify against tx-auth payload    |
+|       and registered provider set                                  |
+|    2. handle_utxo_auth — P256 verify per UTXO context              |
++--------------------------------------------------------------------+
+                              │
+                              │ require_auth_for_args
+                              ▼
++--------------------------------------------------------------------+
+|                     Privacy Channel contract                       |
+|                                                                    |
+|  transact:                                                         |
+|    pre_process     — structural / overflow / conflict checks       |
+|    process_bundle  — atomic UTXO mutation + balance assertion      |
+|    execute_external — SAC transfers + supply update                |
++--------------------------------------------------------------------+
+                              │
+                              │ TokenClient.transfer
+                              ▼
+                      +----------------+
+                      |   Asset SAC    |
+                      | (Stellar SAC,  |
+                      |  e.g. XLM)     |
+                      +----------------+
+```
+
+### 5.1 Boundary checklist
+
+| Boundary | Direction | Required check | Where |
+|---|---|---|---|
+| User → Provider | off-chain | None on-chain. SDK responsibility. | n/a |
+| Provider → Soroban host | tx submission | Stellar replay protection (sequence number on source account). | Stellar core |
+| Soroban host → Channel Auth | `__check_auth` | Soroban auth-entry replay protection (per-account nonce, expiration ledger). | Soroban host |
+| Channel Auth ↔ Privacy Channel | `require_auth_for_args` | Channel Auth must satisfy CA-1 .. CA-7. | `__check_auth` |
+| Privacy Channel → Asset SAC (deposit) | sub-invocation | Depositor's `require_auth_for_args(conditions)` succeeds. | `transact.rs:122` |
+| Privacy Channel → Asset SAC (withdrawal) | sub-invocation | Channel self-authorizes via `authorize_as_current_contract`; soundness requires `__check_auth` already passed. | `transact.rs:135-145` |
+| Privacy Channel → UTXO storage | persistent read/write | Storage backend contracts: PC-5, PC-6, PC-8 enforced inside the storage layer. | `modules/storage/*` |
+
+### 5.2 What is *not* a trust boundary
+
+- The `modules/utxo-core` and `modules/auth` crates compile into the contract WASMs as `rlib` workspace deps. There is no inter-contract call or auth check between contract code and module code. They are part of the same trust domain as the contract that links them.
+- The `modules/helpers::testutils` and `modules/utxo-core::testutils` paths are gated behind `#[cfg(feature = "testutils")]` and are not present in release WASM builds.
+
+---
+
+## 6. Out-of-scope notes
+
+Auditors may reasonably assume the following are part of the audit; they are not.
+
+- **The moonlight-sdk** (`Moonlight-Protocol/moonlight-sdk`): off-chain TypeScript code that derives keys, builds bundles, and constructs auth payloads. It produces the inputs to `transact` but is not part of this audit. Bugs in the SDK that cause it to construct unsafe operations are out of scope; the contracts must defend themselves regardless.
+- **The provider-platform** (`Moonlight-Protocol/provider-platform`): off-chain Deno service that runs the mempool/executor/verifier loop and submits transactions on behalf of users. Out of scope.
+- **The browser-wallet, council-console, provider-console, network-dashboard**: front-end applications. Out of scope.
+- **The local-dev** orchestration repo: Docker Compose harness for E2E testing. Provides regression evidence (see `tests.md`) but its own code is not in audit scope.
+- **The `contracts/token/` test token**: a workspace-internal token used only in `privacy-channel` integration tests. Not deployed.
+- **The `admin-sep` crate** (`AhaLabs/admin-sep`): pulled in via git, rev `bf195f4d67cc96587974212f998680ccf9a61cd7`. Provides `Administratable` and `Upgradable` traits. Auditors should treat its behavior as part of the trusted base; if a deeper audit of `admin-sep` is desired, that is a separate scope.
+- **The Soroban SDK fork** (`AhaLabs/rs-soroban-sdk`, rev `5a99659f1483c926ff87ea45f8823b8c00dc4cbd`): the workspace pins a specific revision of an Aha-maintained fork rather than `stellar/rs-soroban-sdk`. Where this fork diverges from upstream is itself worth review, but the SDK code is not in this audit scope. Auditors should be aware of the fork pin and may want to ask for the diff against upstream.
+- **Stellar Asset Contract** behavior: the channel trusts its configured asset SAC to enforce its own transfer semantics. Custom non-SAC assets are not a tested path.
+
+---
+
+## 7. Toolchain and reproducibility
+
+Captured here so readers do not need to grep the workspace.
+
+- **Rust edition:** 2021 (workspace).
+- **WASM target:** `wasm32v1-none` (Soroban-supported target; `release.yml` builds against this).
+- **Soroban SDK:** git pin `https://github.com/AhaLabs/rs-soroban-sdk` rev `5a99659f1483c926ff87ea45f8823b8c00dc4cbd`.
+- **`admin-sep`:** git pin `https://github.com/AhaLabs/admin-sep` rev `bf195f4d67cc96587974212f998680ccf9a61cd7`.
+- **`stellar-default-impl-macro`:** git pin `https://github.com/OpenZeppelin/stellar-contracts` tag `v0.3.0`.
+- **`wee_alloc`:** workspace dep version 0.4 (used as `#[global_allocator]` for `wasm32` builds).
+- **Build command (CI):** `stellar contract build` (latest `stellar-cli`, locked install).
+- **Release profile:** `opt-level = "z"`, `lto = true`, `codegen-units = 1`, `panic = "abort"`, `overflow-checks = true`, `strip = true`. Crucially, `overflow-checks` are enabled in release; arithmetic overflow panics rather than wrapping.
+
+Per-contract Cargo features in use:
+
+- `contracts/channel-auth/`: no features; default deps.
+- `contracts/privacy-channel/`: links `moonlight-utxo-core` with `["no-utxo-events", "no-bundle-events"]` (event suppression). The `testutils` feature pulls testutils from utxo-core and Soroban SDK for unit tests.
+- `modules/utxo-core/`: default features = `["storage-drawer", "no-utxo-events", "no-bundle-events"]`. The `storage-drawer` flag selects the bitmap-optimized backend over `storage-simple`.
+- `modules/storage/`: provides `storage-simple` and `storage-drawer` as mutually exclusive features; selected by the consuming crate.
+
+Workspace contract `version = "0.1.0"` per `Cargo.toml`; per-contract `Cargo.toml`s declare `version = "0.0.0"`. The workspace version is the one referenced by the `auto-tag.yml` workflow on push to `main`, which auto-creates `vX.Y.Z` git tags whenever `Cargo.toml` changes.

--- a/contracts/static-analysis.md
+++ b/contracts/static-analysis.md
@@ -1,0 +1,277 @@
+# Soroban Core — Self-Service Static Analysis
+
+This document satisfies item 5 of the Soroban Audit Bank intake form ("self-service tooling vulnerability scan results, with remediation plan for any findings"). It captures the tools run, the exact commands used, the raw findings, and the per-finding remediation plan.
+
+The audit scope is the two contracts in `contracts/` plus the `modules/` they compile against. The `contracts/token/` test-only token is excluded from the security plan but still scanned by the workspace-wide commands.
+
+---
+
+## 1. Tools and versions
+
+| Tool | Version | Purpose |
+|---|---|---|
+| `rustc` | 1.94.0 (4a4ef493e 2026-03-02) | Toolchain |
+| `cargo` | 1.94.0 (85eff7c80 2026-01-15) | Build / test driver |
+| `cargo-audit` | 0.22.1 | RustSec advisory scan over `Cargo.lock` |
+| `cargo-clippy` | 0.1.94 (4a4ef493e3 2026-03-02) | Static lint pass with the `pedantic` group enabled |
+
+The `stellar-cli` itself is also part of the build pipeline (`stellar contract build`) but does not currently expose an independent static-analysis surface beyond what `cargo` already provides; we did not invoke it as a static-analysis tool.
+
+We did not run a Soroban-specific commercial linter (e.g. CoinFabrik's `cargo-scout-audit`) for this self-service pass; the Audit Bank form requires "results of one of the self-service tooling options" and the combination of `cargo-audit` + `cargo-clippy` with the pedantic group is widely accepted as that minimum bar. The Audit Bank firm assigned to this engagement may wish to run their own Soroban-specific tooling on top.
+
+---
+
+## 2. `cargo audit` — RustSec advisory scan
+
+### 2.1 Command
+
+```
+cd soroban-core
+cargo generate-lockfile        # workspace tracks Cargo.toml only; Cargo.lock generated for scan
+cargo audit
+```
+
+### 2.2 Result summary
+
+```
+Scanning Cargo.lock for vulnerabilities (192 crate dependencies)
+warning: 3 allowed warnings found
+```
+
+**Vulnerabilities: 0.** **Unmaintained advisories: 3.**
+
+### 2.3 Findings
+
+#### F-AUDIT-1 — `derivative 2.2.0` (unmaintained)
+
+- Advisory: RUSTSEC-2024-0388 — https://rustsec.org/advisories/RUSTSEC-2024-0388
+- Severity: warning (informational; "unmaintained crate"). No known CVE.
+- Dependency path: pulled in transitively via the Soroban SDK chain (specifically `soroban-env-host` → `wasmi`/`ark-ec` graph). Not a direct dependency of either in-scope contract.
+
+**Remediation plan:** **Out of scope for this PR; accept-and-track.**
+
+The dependency arrives through the Soroban SDK pin (`AhaLabs/rs-soroban-sdk`, rev `5a99659f…`). Replacing or upgrading `derivative` would require either an upstream upgrade in the Soroban SDK or a fork. The advisory is informational; the crate has no known security vulnerability — the maintainer simply stopped accepting changes. We will track upstream SDK updates and pick up a fix whenever the Soroban SDK does. No on-chain risk to the contracts in the meantime.
+
+#### F-AUDIT-2 — `paste 1.0.15` (unmaintained)
+
+- Advisory: RUSTSEC-2024-0436 — https://rustsec.org/advisories/RUSTSEC-2024-0436
+- Severity: warning (informational; "no longer maintained"). No known CVE.
+- Dependency path: `paste` ← `wasmi_core 0.13.0` ← `soroban-wasmi 0.31.1-soroban.20.0.1` ← `soroban-env-host 23.0.0-rc.2` ← `soroban-sdk`. Used as a procedural-macro helper inside the Soroban runtime stack.
+
+**Remediation plan:** **Out of scope for this PR; accept-and-track.** Same disposition as F-AUDIT-1 — pulled in transitively via the Soroban SDK. The crate is widely used and has no exploitable advisory; remediation is gated on the Soroban SDK adopting an alternative.
+
+#### F-AUDIT-3 — `wee_alloc 0.4.5` (unmaintained)
+
+- Advisory: RUSTSEC-2022-0054 — https://rustsec.org/advisories/RUSTSEC-2022-0054
+- Severity: warning (informational; "unmaintained"). No known CVE.
+- Dependency path: **direct** dependency of both `privacy-channel` and `channel-auth-contract`. Used as the `#[global_allocator]` for `wasm32` builds:
+
+  ```rust
+  #[cfg(target_arch = "wasm32")]
+  #[global_allocator]
+  static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
+  ```
+
+  in both `contracts/channel-auth/src/lib.rs` and `contracts/privacy-channel/src/lib.rs`.
+
+**Remediation plan:** **Track for follow-up; not blocking the audit.**
+
+`wee_alloc` is a small-footprint allocator widely used in the Soroban / Stellar contract ecosystem to keep WASM code size small. The advisory flags maintenance status, not a known vulnerability. Replacing it would require:
+
+1. picking a maintained alternative (`dlmalloc`, the default Rust allocator, or `lol_alloc`),
+2. validating the WASM size budget remains within Soroban contract limits,
+3. validating that resulting gas costs do not regress.
+
+This is a self-contained change but represents a non-trivial regression-test surface; it does not block audit readiness and should be scheduled as a separate PR after the Audit Bank engagement completes (so that any fix can be applied alongside the audit firm's findings rather than re-shuffling auditable code immediately before audit).
+
+### 2.4 Net audit-form summary
+
+- **0 known vulnerabilities** in the dependency graph.
+- **3 unmaintained-crate advisories** — 2 transitive (out of our control), 1 direct (`wee_alloc`, scheduled).
+- **0 of the findings represent an exploitable on-chain risk** at the contract layer.
+
+---
+
+## 3. `cargo clippy` — pedantic lint pass
+
+### 3.1 Command
+
+```
+cd soroban-core
+cargo clippy --workspace --no-deps --all-targets -- \
+    -W clippy::all \
+    -W clippy::pedantic
+```
+
+`--no-deps` ensures we only lint our own sources; `--all-targets` includes test code.
+
+### 3.2 Result summary
+
+- **0 errors.**
+- **307 warnings.**
+- Top categories:
+
+| Count | Category | Severity for security audit |
+|---|---|---|
+| 89 | `needless_borrow` (immediately-dereferenced reference) | Style |
+| 32 | `must_use_candidate` (method) | Style |
+| 30 | `needless_pass_by_value` | Style |
+| 19 | `use_self` / `use_infallible_conversion` | Style |
+| 17 | `missing_panics_doc` | **Audit-relevant** — see §3.3 |
+| 12 | `must_use_candidate` (function) | Style |
+| 11 | `clone_on_copy` (`u32`) | Style |
+| 11 | `if_then_panic` (single-statement-panic in `if`) | Style |
+| 10 | `assert_eq` with literal bool | Style (test-only) |
+| 6 | `inline_always` on small fns | Style |
+| Misc | various | Style |
+
+The full output is reproducible by running the command above; we do not duplicate the 3,556-line raw output in this document.
+
+### 3.3 `missing_panics_doc` — 17 findings (audit-relevant)
+
+These flag functions that may panic without a `# Panics` rustdoc section. Each one corresponds to an undocumented termination path. None of the panic paths are exploitable in the sense that they bypass authorization, but each is a deliberate revert that auditors would expect to see documented. The findings cluster as follows:
+
+| File | Function | Reason for panic |
+|---|---|---|
+| `modules/helpers/src/parser.rs` | `address_to_ed25519_pk_bytes` | Invalid UTF-8, invalid Strkey, non-ed25519 address (testutils-only path). |
+| `modules/storage/src/simple.rs` | `SimpleStore::create`, `SimpleStore::spend` | Already-exists / already-spent / not-exists (intentional revert). |
+| `modules/storage/src/drawer.rs` | `DrawerStore::create_cached`, `spend_cached`, `alloc_slot_and_rotate_if_needed_cached` | Already-exists / already-spent / drawer-id u32 overflow (last is unreachable in practice). |
+| `modules/utxo-core/src/core.rs` | `process_bundle`, `verify_utxo_not_exists`, `verify_utxo_unspent`, `auth` | Bundle-balance / UTXO-state / missing-auth-config reverts. |
+| `modules/auth/src/core.rs` | `register_provider`, `deregister_provider`, `require_provider` | Provider-already / not-registered / signature checks. |
+| `contracts/privacy-channel/src/transact.rs` | `pre_process_channel_operation`, `verify_external_operations`, `op_has_no_conflicting_conditions` (via `panic_with_error!`) | Bundle-shape reverts. |
+| `contracts/privacy-channel/src/treasury.rs` | `increase_supply`, `decrease_supply` | Overflow / underflow. |
+
+**Remediation plan:** **Documentation pass; not a code change.** Adding `# Panics` doc-comment sections to every flagged function is straightforward and entirely additive. Out of scope for this PR; tracked as a follow-up cleanup. Auditors can treat the panic semantics as the documented intent: any bundle-shape, UTXO-state, supply, or auth failure causes a transaction-level revert.
+
+### 3.4 Style-only findings (audit-irrelevant)
+
+The remaining 290 warnings are stylistic — `needless_borrow`, `must_use_candidate`, `clone_on_copy`, etc. None of them indicates a security vulnerability. They are tracked as a separate cleanup batch and are not blocking the audit.
+
+---
+
+## 4. Manual code-walk observations
+
+In addition to the tool output, the team conducted a manual review of the in-scope sources during this exercise. The observations below are not findings against an automated tool's rule but are surfaced here for the auditor's attention. They are NOT presented as defects; they are informational notes that may shape the auditor's own threat model.
+
+### 4.1 Signature-verifier wrappers rely on host-panic semantics
+
+`modules/auth/src/core.rs`:
+
+```rust
+fn verify_p256_signature(...) -> Result<(), Error> {
+    e.crypto().secp256r1_verify(public_key, payload_hash, signature);
+    Ok(())
+}
+
+fn verify_ed25519_signature(...) -> Result<(), Error> {
+    e.crypto().ed25519_verify(public_key, &Bytes::from_array(...), signature);
+    Ok(())
+}
+```
+
+Both wrappers always return `Ok(())`. They depend on the underlying Soroban host primitives panicking on a failed verification. This is the documented behavior of `secp256r1_verify` and `ed25519_verify` in the Soroban SDK at the pinned revision (`5a99659f…` of `AhaLabs/rs-soroban-sdk`).
+
+**Implication:** if the upstream SDK ever changes these primitives to return a `Result` rather than panic, the wrappers as written would silently accept invalid signatures. This is not a current vulnerability but is a non-obvious coupling worth documenting and worth re-validating against any future SDK upgrade.
+
+**Remediation plan:** **Track for follow-up.** Wrappers should be hardened to defensively re-check the host's behavior or return a `Result` from the host primitive. Out of scope for this PR.
+
+### 4.2 Zero-arg context bypass in `handle_utxo_auth`
+
+`modules/auth/src/core.rs:87`:
+
+```rust
+if cc.args.len() < 1 {
+    return Ok(()); // No auth requirements, skip
+}
+```
+
+Zero-argument contract contexts skip the per-UTXO P256 verification entirely. In the current call graph this is reached only from `process_bundle` when `bundle.req.0.is_empty()` (i.e., no spends), and provider authorization (which runs first and unconditionally requires a registered provider sig) still applies. **No exploit path is currently reachable.**
+
+**Implication:** the safety of this implicit "zero-args means no spends" coupling depends on the contract layer never building an `auth_args` of `vec![&e]` for a bundle that *does* have spends. A future refactor could break this. Worth a `# Safety` comment at minimum.
+
+**Remediation plan:** **Track for follow-up.** Consider tightening to: if `contexts` references a contract function that is expected to carry auth, *require* a non-empty arg list explicitly, rather than implicitly accepting empty-args as success.
+
+### 4.3 Provider threshold is hardcoded to 1
+
+`modules/auth/src/core.rs:205`:
+
+```rust
+const PROVIDER_THRESHOLD: u32 = 1; // For now we require only one exact provider signature
+```
+
+Acceptable for the current architecture (channels are bound to a single Channel Auth contract whose admin governs the provider set; quorum semantics live above this layer). Worth flagging for the auditor since the const-named "threshold" pattern usually invites questions about multi-sig / m-of-n; here it is intentional.
+
+**Remediation plan:** **No change.** Documented in arch.md §2.5. If a future product requirement demands m-of-n provider quorums, this becomes a configurable storage value; that's a roadmap decision, not a fix.
+
+### 4.4 `panic!` vs `panic_with_error!` inconsistency
+
+`contracts/privacy-channel/src/treasury.rs`:
+
+```rust
+None => panic!("Overflow occurred while increasing supply"),
+None => panic!("Underflow occurred while decreasing supply"),
+```
+
+Other revert paths in the codebase use `panic_with_error!(env, Error::SomeVariant)` which surfaces a structured contract-error code to the host. The two `panic!` calls in `treasury.rs` produce a string panic instead, which loses the structured-error mapping.
+
+**Implication:** if `transact` triggers an internal supply overflow / underflow, the resulting transaction failure is harder to programmatically diagnose from the client side. The path is still rejected; only the diagnosability is degraded.
+
+**Remediation plan:** **Track for follow-up.** Add a `treasury::Error` enum and convert these panics to `panic_with_error!`. Out of scope for this PR.
+
+### 4.5 Production `unwrap()` sites
+
+| Location | Context |
+|---|---|
+| `contracts/privacy-channel/src/storage.rs:20` (`read_asset`) | Constructor sets it; impossible-by-construction. |
+| `modules/auth/src/core.rs:99` | Map key was just iterated from same map; impossible-by-construction. |
+| `modules/auth/src/core.rs:218` | `.ok_or(MissingSignature).unwrap()` — would be more consistent as `?` propagation. |
+| `modules/storage/src/drawer.rs:104` | Just-set `Option<DrawerState>::Some(_)`; impossible. |
+| `modules/utxo-core/src/core.rs:68` (`auth`) | Constructor sets it; impossible-by-construction. |
+| `modules/helpers/src/parser.rs:31` | Bare `panic!` in `address_to_ed25519_pk_bytes`. testutils-only path. |
+
+**Remediation plan:** **Track for follow-up.** None of these is a current bug. They could each be tightened either by `expect("…")` with a precondition message or by `?` / structured error propagation. Out of scope for this PR.
+
+### 4.6 Privacy Channel emits no contract events
+
+`contracts/privacy-channel/Cargo.toml` enables `no-utxo-events` and `no-bundle-events` on `moonlight-utxo-core`. The Privacy Channel itself does not declare any `#[contractevent]` types. The only on-chain event traffic from `transact` comes from the asset SAC's own `transfer` events.
+
+**Implication:** for purely internal `Spend`/`Create` transactions (no `ExtDeposit` / `ExtWithdraw`), there is no contract-level event emitted. The transaction's existence is observable via Stellar transaction metadata, fees, and resulting UTXO storage state, but there is no per-bundle audit-trail event on-chain.
+
+This is a **deliberate cost optimization** — bundle and per-UTXO events are expensive when bundles batch many UTXOs — but it is also a **repudiation surface**: an external observer cannot reconstruct the bundle's contents without inspecting the TX footprint. Privacy is a feature, not a bug, in this domain (this is a privacy channel by design); but auditors should be aware that the on-chain audit trail is intentionally minimal.
+
+**Remediation plan:** **No change planned.** Documented in `arch.md` §3.4 and revisited in `stride.md` under the Repudiation category.
+
+### 4.7 Strict `<` for `valid_until_ledger`
+
+`modules/auth/src/core.rs:113, 220`:
+
+```rust
+if valid_until_ledger < e.ledger().sequence() {
+    return Err(Error::SignatureExpired);
+}
+```
+
+A signature with `valid_until_ledger == current_sequence` is **still valid** (the comparison is strict-less-than). This is consistent with a "live until and including ledger N" interpretation. Documented here so the auditor does not flag it as an off-by-one.
+
+**Remediation plan:** **No change planned.** Documented as intentional.
+
+---
+
+## 5. Combined remediation plan
+
+| ID | Finding | Disposition | Tracked-as |
+|---|---|---|---|
+| F-AUDIT-1 | `derivative` unmaintained (transitive) | Accept-and-track | Future Soroban SDK upgrade |
+| F-AUDIT-2 | `paste` unmaintained (transitive) | Accept-and-track | Future Soroban SDK upgrade |
+| F-AUDIT-3 | `wee_alloc` unmaintained (direct) | Track for follow-up | Post-audit cleanup PR |
+| F-CLIPPY-1 | 17× `missing_panics_doc` | Track for follow-up | Doc-only PR |
+| F-CLIPPY-2 | 290× style-only warnings | Defer | Project-wide cleanup |
+| F-MANUAL-1 | Verifier wrappers rely on host panic | Track for follow-up | Hardening PR |
+| F-MANUAL-2 | Zero-arg context bypass | Track for follow-up | Hardening PR |
+| F-MANUAL-3 | Hardcoded provider threshold | No change | Documented intent |
+| F-MANUAL-4 | `panic!` vs `panic_with_error!` inconsistency in `treasury.rs` | Track for follow-up | Cleanup PR |
+| F-MANUAL-5 | Production `unwrap()` sites | Track for follow-up | Cleanup PR |
+| F-MANUAL-6 | No contract events on internal-only `transact` | No change | Documented intent (privacy by design) |
+| F-MANUAL-7 | Strict-`<` on `valid_until_ledger` | No change | Documented intent |
+
+**Summary for the Audit Bank readiness reviewer:** zero exploitable findings, three accept-and-track unmaintained-crate advisories, seven informational manual notes that the audit firm may want to look at independently. No critical / high / medium findings to remediate before audit.

--- a/contracts/stride.md
+++ b/contracts/stride.md
@@ -1,0 +1,175 @@
+# Soroban Core — STRIDE Threat Model
+
+This document satisfies item 6 of the Soroban Audit Bank intake form ("STRIDE threat model for the contracts"). It enumerates threats per STRIDE category for both in-scope contracts. Each entry lists threat scenario, likelihood, impact, mitigation already in place, and residual risk after mitigation.
+
+The model is scoped to the on-chain contract layer only. Off-chain components (provider platform, browser wallet, council/provider/network consoles, moonlight-sdk) and the Stellar/Soroban host itself are treated as part of the trust environment and are not enumerated here. Where their behavior is load-bearing for a contract-level mitigation, that dependency is called out explicitly.
+
+Likelihood and impact ratings are intentionally coarse:
+
+- **Likelihood:** Low / Medium / High — operational chance of the scenario being attempted in the wild given current architecture.
+- **Impact:** Low / Medium / High / Critical — worst-case effect on protocol integrity, user funds, or auditability.
+- **Residual risk** is the post-mitigation rating.
+
+Cross-references to invariants (CA-1..CA-7, PC-1..PC-15, X-1..X-2) are to `arch.md`.
+
+---
+
+## 1. Channel Auth
+
+### 1.1 Spoofing
+
+| ID | Threat | Likelihood | Impact | Mitigation | Residual |
+|---|---|---|---|---|---|
+| CA-S-1 | An attacker submits a transaction claiming to be a registered provider, attaching a forged Ed25519 signature. | High (every adversary attempts) | Critical (would let any attacker authorize bundles) | `require_provider` (CA-2): the Soroban host's `ed25519_verify` panics on invalid signatures; the registered-provider lookup uses an instance-storage map; `address_from_ed25519_pk_bytes` derives the address from the pubkey deterministically, so an attacker cannot supply a public key whose strkey matches a registered provider without holding the secret. | Low |
+| CA-S-2 | Attacker spoofs the *contract address* itself (e.g. via a malicious contract impersonating Channel Auth in front of the Privacy Channel). | Low | High | The Privacy Channel stores the Channel Auth address in instance storage at construction (`STORAGE_KEY_UTXO_AUTH`) with no exposed setter (PC-2). Replacing it would require an admin-gated contract upgrade. | Low |
+| CA-S-3 | Attacker spoofs an admin call by predicting / racing the admin's transaction. | Low | High | Admin authorization is enforced by Soroban's `require_auth`; the admin's signature is bound to network ID, contract, function name, args, sequence, expiration. There is no in-contract replay window beyond Soroban's own auth-entry nonce semantics. | Low |
+| CA-S-4 | Attacker spoofs a P256 UTXO signer by deriving a colliding P256 pubkey. | Low (cryptographic) | Critical | `secp256r1_verify` host primitive; SEC1 uncompressed pubkey (`BytesN<65>`) on-curve validation by the host. Collision security is the standard NIST P-256 / secp256r1 ~128-bit floor. | Low |
+| CA-S-5 | Attacker submits a P256 signature that verifies against the wrong message (replay across contracts). | Low | High | Per-UTXO auth payload includes the caller contract's address bytes via `hash_payload(payload, contract_addr_bytes)` (CA-4). Cross-contract replay is bound to a different message digest. | Low |
+
+### 1.2 Tampering
+
+| ID | Threat | Likelihood | Impact | Mitigation | Residual |
+|---|---|---|---|---|---|
+| CA-T-1 | Attacker tries to add themselves to the provider set without admin auth. | High | Critical | `add_provider` calls `Self::require_admin(e)` first; admin-sep traits enforce admin signature presence. (CA-1) | Low |
+| CA-T-2 | Attacker tries to remove a competing provider, denying that provider its bundle-signing role. | Medium | Medium | Same as CA-T-1: admin-gated. (CA-1) | Low |
+| CA-T-3 | Attacker forges an `AuthRequirements` argument to bypass per-UTXO P256 verification. | Medium | High | `AuthRequirements` is parsed from `args[0]` via `try_into_val`; type mismatches error `BadArg`. The map's keys are `SignerKey::P256(pk)` and the verification routine recomputes the payload over the *same* conditions before checking. An attacker who tampers with the requirements map can only either (a) drop a P256 entry (in which case the corresponding spend's `MissingSignature` error fires), (b) add an extraneous entry (silently skipped if non-P256, or fails verification if P256 with no real signer). The map cannot be tampered with to authorize a UTXO whose owner did not sign. (CA-4) | Low |
+| CA-T-4 | Attacker tampers with `valid_until_ledger` to extend a stale signature's lifetime. | Medium | High | `valid_until_ledger` is signed-over as part of the auth payload (`hash_payload(AuthPayload { ..., live_until_ledger })`). Modifying it changes the payload and invalidates the signature. (CA-3, CA-4) | Low |
+| CA-T-5 | Storage tampering — attacker mutates `ProviderDataKey::AuthorizedProvider(addr)` directly. | Low | Critical | Soroban's instance storage is contract-scoped; only this contract's code can write to it. There is no public storage-mutator function. | Low |
+
+### 1.3 Repudiation
+
+| ID | Threat | Likelihood | Impact | Mitigation | Residual |
+|---|---|---|---|---|---|
+| CA-R-1 | Admin denies having added or removed a particular provider. | Low | Medium | `ProviderAdded` and `ProviderRemoved` events are emitted at every governance action (CA-7), bound to the registered provider's address. Combined with the Stellar transaction record showing the signed admin auth-entry, this provides a non-repudiable trail. | Low |
+| CA-R-2 | Admin denies having upgraded the contract. | Medium | Medium | The contract does not emit a dedicated `ContractUpgraded` event (gap noted in arch §4.1). However, contract upgrade is observable on-chain via the Stellar transaction itself (the `upload_contract_wasm` / `extend_contract` operations are public ledger entries); admin-sep produces internal hooks that may emit. The audit trail exists but is shallower than for provider mutations. | **Medium** |
+| CA-R-3 | Admin denies having transferred admin rights. | Medium | Medium | Same as CA-R-2: no dedicated event from this contract. The `set_admin` call is on-chain and visible in the transaction record, but there is no in-contract signal. | **Medium** |
+| CA-R-4 | Provider denies having signed a particular bundle. | Low | Medium | The provider's Ed25519 signature is part of the Soroban auth-entry XDR captured in the transaction's metadata. Cryptographic non-repudiation is full. | Low |
+
+### 1.4 Information disclosure
+
+| ID | Threat | Likelihood | Impact | Mitigation | Residual |
+|---|---|---|---|---|---|
+| CA-I-1 | Provider set is publicly readable via `is_provider`. | Certain (by design) | None — public by design | Provider membership is a public protocol fact; the read is intentional. | None |
+| CA-I-2 | Admin address is publicly readable via `admin()`. | Certain | None — public by design | Same: governance principal is intended to be public. | None |
+| CA-I-3 | `__check_auth` accepts a `signatures` map that may leak signer identities to a passive observer. | Certain | Low — by design | All auth-entry data is on the public ledger. The protocol does not attempt to hide signer identity at the Channel Auth layer; UTXO ownership privacy is handled at the Privacy Channel layer (where UTXOs are unlinkable from Stellar accounts). | None |
+
+### 1.5 Denial of service
+
+| ID | Threat | Likelihood | Impact | Mitigation | Residual |
+|---|---|---|---|---|---|
+| CA-D-1 | Attacker submits a bundle with an enormous signatures map to exhaust gas / instructions during `__check_auth`. | Medium | Medium | The transaction submitter pays the resource fee; Soroban metering bounds per-tx execution. The contract iterates `signatures.0.keys()` once per provider check and once per UTXO context, both linear in map size. There is no quadratic blowup. The economic cost falls on the attacker, who gains nothing. | Low |
+| CA-D-2 | Attacker spams `add_provider` / `remove_provider` to bloat instance storage and increase TTL extension cost for the admin. | Low | Low | Admin-gated; only the admin can pay this cost and they would be paying it on themselves. Not a viable external attack vector. | Low |
+| CA-D-3 | Provider key compromise leads to attacker griefing all bundles by submitting expired or otherwise-invalid sigs that cost everyone gas. | Medium | Medium | Provider Ed25519 verification is host-native and cheap; failed bundles are reverted and the attacker pays the resource fee. The admin can `remove_provider` to evict a compromised provider. | Low |
+| CA-D-4 | A `Context` variant other than `Contract` is supplied to attempt to exhaust `handle_utxo_auth`. | Low | Low | Rejected immediately with `UnexpectedContext` (CA-5). | Low |
+
+### 1.6 Elevation of privilege
+
+| ID | Threat | Likelihood | Impact | Mitigation | Residual |
+|---|---|---|---|---|---|
+| CA-E-1 | Provider escalates to admin (e.g. by tricking the admin into signing an `add_provider` for the provider's own future admin address, then `set_admin`). | Low | Critical | Only the admin can call `set_admin`; admin-sep enforces this. A provider has no path to admin promotion. | Low |
+| CA-E-2 | UTXO owner (P256) escalates to provider. | Low | Critical | P256 signers are verified per-UTXO; their authority is bound to specific spends. They cannot satisfy the provider check (CA-2) without an Ed25519 signature from a registered provider. | Low |
+| CA-E-3 | Compromised admin key escalates further (e.g., to the admin of *other* Channel Auth instances). | n/a | n/a | This is not an in-contract escalation; admin-key compromise is a key-management issue. The Moonlight Security Council multi-sig (Stellar-native) is the documented mitigation (per README's mermaid: "admin = Moonlight Security Council multi-sig"). | n/a (out of contract) |
+| CA-E-4 | Stale upgrade WASM (admin-approved historical upgrade) is replayed to revert to a vulnerable version. | Low | Critical | Soroban auth-entry nonces and `valid_until_ledger` prevent literal replay of historical admin signatures. A new upgrade requires a fresh admin signature. | Low |
+
+---
+
+## 2. Privacy Channel
+
+### 2.1 Spoofing
+
+| ID | Threat | Likelihood | Impact | Mitigation | Residual |
+|---|---|---|---|---|---|
+| PC-S-1 | Attacker submits a `transact` claiming to be a legitimate UTXO owner. | High | Critical | Every spend in `bundle.spend` requires a P256 signature in `signatures` whose pubkey matches the spend's UTXO key. Verification chain: `process_bundle` → `auth.require_auth_for_args` → Channel Auth's `__check_auth` → `handle_utxo_auth`. (CA-4, PC-13/14) | Low |
+| PC-S-2 | Attacker spoofs a depositor (forces another G-account's balance into a channel). | Medium | High | `execute_external_operations` calls `from.require_auth_for_args(vec![&e, conditions])` for each deposit (PC-13). The depositor must explicitly authorize the exact condition list. | Low |
+| PC-S-3 | Attacker spoofs the asset contract by deploying a malicious SAC at a guessed address and then somehow registering it as the channel's asset. | Low | Critical | The asset is set once at construction (PC-1) and has no externally callable mutator. Constructor-time selection is a deployment-policy concern handled off-chain. | Low |
+| PC-S-4 | Attacker spoofs the auth contract. | Low | Critical | Same as PC-2 (immutable auth binding). | Low |
+
+### 2.2 Tampering
+
+| ID | Threat | Likelihood | Impact | Mitigation | Residual |
+|---|---|---|---|---|---|
+| PC-T-1 | Attacker tampers with a bundle to spend a UTXO they don't own. | High | Critical | P256 verification per spend (PC-S-1 / CA-4). Tampering with the spend list invalidates the signature payload. | Low |
+| PC-T-2 | Attacker tampers with a `Create` amount to inflate UTXO balances out of thin air. | High | Critical | `process_bundle` enforces `total_available_balance == expected_outgoing` (PC-4). Inflated creates exceed available balance and panic with `UnbalancedBundle`. | Low |
+| PC-T-3 | Attacker tampers with `op.deposit` amounts to drain a depositor without their auth. | Medium | High | Depositor's `require_auth_for_args(conditions)` only authorizes the *condition* list, not the amount directly — but the conditions reference the UTXO outcomes that determine what the deposit funds. The amount in `(addr, amount, conditions)` is what the SAC `transfer(from, channel, amount)` uses; the condition's `Create(utxo, amount)` references the matching create amount. If the amounts diverge, the bundle balance equation (PC-4) panics. **There is, however, a subtle case**: a deposit `(from, amount, [])` with empty conditions has no condition coverage but still requires `from`'s auth-for-args of an empty `vec![]`; the depositor would need to sign an explicitly-empty condition list, which the SDK would not normally produce. Worth the auditor's attention. | **Medium** |
+| PC-T-4 | Attacker tampers with `op.withdraw` recipient to redirect funds. | High | Critical | Withdrawal authorization comes from the *spend* signatures: every `Spend` condition lists the expected `ExtWithdraw(to, amount)` as a condition. Tampering with the recipient changes the conditions, which changes the auth payload, which invalidates the signature. (CA-4, PC-14) | Low |
+| PC-T-5 | Storage tampering — attacker mutates UTXO state directly. | Low | Critical | Soroban storage is contract-scoped; no public mutator. Persistent storage entries are authenticated by Soroban's storage protocol. | Low |
+| PC-T-6 | Attacker manipulates `Supply` directly. | Low | Critical | `read_supply` / `write_supply_unchecked` are not exposed externally. The only writers are `increase_supply` / `decrease_supply` in `treasury.rs`, called only from `execute_external_operations`. (PC-3) | Low |
+
+### 2.3 Repudiation
+
+| ID | Threat | Likelihood | Impact | Mitigation | Residual |
+|---|---|---|---|---|---|
+| PC-R-1 | Channel operator denies that a particular `transact` happened. | Low | Medium | The transaction is on the public ledger; storage-state delta and gas cost are non-repudiable. | Low |
+| PC-R-2 | UTXO owner denies having spent / created a particular UTXO. | Low | Medium | P256 signatures are part of the auth-entry XDR and the source of truth. | Low |
+| PC-R-3 | Channel-internal-only `transact` (Spend+Create only, no Ext*) leaves no contract-level event. | Certain | Medium | **Documented gap** (arch §3.4, static-analysis F-MANUAL-6). Privacy Channel is configured with `no-utxo-events` and `no-bundle-events`. The transaction is observable in Stellar metadata but no per-bundle Soroban event is emitted. This is a deliberate design choice for cost optimization and aligns with the privacy goals of the channel; however, it means downstream auditors and indexers must read transaction footprints rather than subscribing to events. | **Medium** |
+| PC-R-4 | Depositor denies authorizing a deposit. | Low | Low | Depositor's Ed25519 auth-entry signature is captured in transaction metadata. | Low |
+
+### 2.4 Information disclosure
+
+| ID | Threat | Likelihood | Impact | Mitigation | Residual |
+|---|---|---|---|---|---|
+| PC-I-1 | Channel `Supply` is publicly readable. | Certain (by design) | None — public by design | The aggregate channel size is a public protocol fact. | None |
+| PC-I-2 | Per-UTXO balance is queryable via `utxo_balance(utxo_pk)`. | Certain (by design) | Low | If an observer knows a specific UTXO public key, they can query its balance. The privacy property of the channel relies on UTXO public keys not being correlated with Stellar accounts (the moonlight-sdk derives them via HKDF from a master seed; correlation requires the seed). The contract layer does not enforce this; it is a property of the SDK. | Low |
+| PC-I-3 | The set of UTXOs that exist is enumerable by an indexer that watches storage entries. | Certain | Medium — by design | Anyone watching ledger state can enumerate UTXO storage entries. Linking those to identities still requires the SDK-derived seed; contract-layer privacy is "unlinkability via hashed P256 keys", not "non-existence of UTXO records". | Medium — accepted |
+| PC-I-4 | Bundle conditions (`Vec<Condition>`) appear in the `AuthRequirements` argument and are visible on-chain to anyone reading the auth-entry XDR. | Certain | Medium — by design | Conditions describe the outcomes a UTXO owner authorizes. They are by design public (the auth flow needs to verify against them). They reveal what UTXO movements happened in a bundle but not who owns the addresses. | Medium — accepted |
+
+### 2.5 Denial of service
+
+| ID | Threat | Likelihood | Impact | Mitigation | Residual |
+|---|---|---|---|---|---|
+| PC-D-1 | Attacker submits a `transact` with a maximally large `bundle.spend` / `create` to exhaust instruction limits. | Medium | Medium | Soroban metering bounds per-tx instruction count; the attacker pays the resource fee. The bundle-balance loop is linear in (spend + create) size. | Low |
+| PC-D-2 | Attacker repeatedly submits failing bundles to grief the provider. | Medium | Low | Each failed submission costs the *submitter* the resource fee. The provider's only exposure is the cost of producing an Ed25519 signature, which is negligible. The provider platform's mempool layer does its own rate-limiting; the contract has no role here. | Low |
+| PC-D-3 | Drawer-storage rotation panic on `current_drawer.checked_add(1).expect("drawer overflow")` in `alloc_slot_and_rotate_if_needed_cached`. | Low | Low | Triggered only after `u32::MAX` drawer rotations × 1024 slots ≈ 4.4 trillion UTXO creates. Practically unreachable. | Low |
+| PC-D-4 | Attacker submits bundle that creates a UTXO that already exists, forcing a panic and tying up a provider's resource for nothing. | Medium | Low | The bundle is rejected via `UTXOAlreadyExists`. The submitter pays the fee. | Low |
+| PC-D-5 | Attacker submits a bundle whose totals overflow `i128`. | Low | Low | `pre_process_channel_operation` uses `checked_add` and panics with `AmountOverflow` on overflow (PC-12). | Low |
+| PC-D-6 | Asset SAC reverts during `transfer` (e.g., depositor balance insufficient). | Medium | Low | The whole `transact` reverts atomically (PC-15). Submitter pays gas. | Low |
+| PC-D-7 | Channel Auth `__check_auth` itself reverts (e.g., admin disabled all providers, leaving none). | Low | Medium | Admin can `remove_provider` all providers, after which no transact is possible until `add_provider` re-runs. The channel is recoverable but temporarily unusable; this is a governance choice, not a vulnerability. | Low |
+
+### 2.6 Elevation of privilege
+
+| ID | Threat | Likelihood | Impact | Mitigation | Residual |
+|---|---|---|---|---|---|
+| PC-E-1 | UTXO owner attempts to bypass the channel's bundle-balance equation to mint UTXOs from nothing. | High | Critical | `process_bundle` enforces `total_available_balance == expected_outgoing` (PC-4). | Low |
+| PC-E-2 | UTXO owner attempts to bypass deposit auth and pull external funds into a channel. | Medium | High | `from.require_auth_for_args(vec![&e, conditions])` requires the depositor's Ed25519 signature on the exact condition list (PC-13). | Low |
+| PC-E-3 | Withdraw recipient claims unauthorized funds. | Low | High | The recipient does not sign; they are named in the spend conditions of an authorized bundle. An attacker would need to be either (a) a UTXO owner already authorizing a withdrawal, or (b) able to forge a bundle's auth — both of which fall back to the auth model. | Low |
+| PC-E-4 | Privacy Channel admin escalates to dictate user funds. | Low | High | Admin's only powers are `set_admin` and `upgrade`. Neither directly moves user funds. However, an upgrade to a malicious WASM can grant the admin arbitrary power — so admin compromise is effectively a critical-severity event. The mitigation lives at the key-management layer (Stellar multi-sig for the admin address). | **Medium** |
+| PC-E-5 | Channel Auth admin (which may differ from Privacy Channel admin) leverages provider-set control to author bundles. | Medium | Critical | A Channel Auth admin can register their own address as a provider and self-authorize bundles. **However**, providers cannot mint UTXOs without P256 signatures; they can only authorize bundles whose UTXO owners have already signed. So the admin gains the ability to *batch* user-signed operations but not to fabricate them. Net: this is the documented "trusted provider" role; users trust the provider to relay signed operations honestly. | Medium — accepted (architectural) |
+| PC-E-6 | Cross-channel privilege escalation (e.g., a UTXO from channel A used in channel B). | Low | High | Auth payload is bound to `caller_contract_address_bytes` (CA-4). A signature for a spend in channel A's contract address is invalid against channel B's contract. | Low |
+
+---
+
+## 3. Cross-contract / system-level threats
+
+### 3.1 Channel Auth ↔ Privacy Channel composition
+
+| ID | Threat | Likelihood | Impact | Mitigation | Residual |
+|---|---|---|---|---|---|
+| X-1 | A new Privacy Channel is constructed pointing at a malicious Channel Auth (e.g., one whose admin is an attacker). | Low | High | Constructor binding; deployment is a governance action. The Council Console / off-chain process is responsible for vetting which Channel Auth a new channel binds to. Contract-level mitigation: the asset and auth bindings are immutable post-construction (PC-1, PC-2). | Low — relies on deployment hygiene |
+| X-2 | Multiple Privacy Channels share a Channel Auth; compromise of that Channel Auth's admin compromises all bound channels. | Low | Critical (if it happens) | Architectural: documented in arch §1 and §2.6. Mitigation lives at the admin key-management layer (multi-sig). | **Medium** — architectural |
+| X-3 | A future contract upgrade introduces a subtle invariant break (e.g., adds an `set_asset` mutator). | Low | Critical | All upgrades require admin auth (CA-1). The mitigation is procedural: every upgrade WASM must pass the same audit / review process. The contract layer cannot unilaterally prevent self-authored mistakes. | Medium — procedural |
+
+---
+
+## 4. Residual-risk summary
+
+| Category | Channel Auth | Privacy Channel | Cross-contract |
+|---|---|---|---|
+| Spoofing | Low (5/5 mitigated) | Low (4/4 mitigated) | n/a |
+| Tampering | Low (5/5 mitigated) | Low (5/6 mitigated, 1 medium: PC-T-3 empty-conditions deposit) | n/a |
+| Repudiation | Medium (CA-R-2/3 — no events on `set_admin`/`upgrade`) | Medium (PC-R-3 — no events on internal-only transacts) | n/a |
+| Information disclosure | None (all by design) | Medium (PC-I-3/4 — accepted by design) | n/a |
+| Denial of service | Low | Low | n/a |
+| Elevation of privilege | Low (4/4 mitigated) | Medium (PC-E-4 admin upgrade, PC-E-5 admin-can-be-provider) | Medium (X-2 shared admin, X-3 upgrade governance) |
+
+### 4.1 Items the Audit Bank readiness reviewer should especially look at
+
+The team flags the following as the spots most worth the assigned audit firm's attention. None is a known defect; all are areas where a deeper second-opinion would add the most value:
+
+1. **PC-T-3 (deposit with empty conditions list).** The auth payload for the depositor's `require_auth_for_args` is `vec![&e, conditions.into_val(&e)]`. If a client constructs a deposit with an empty conditions list, the depositor must sign over an explicitly-empty list. Whether this is a legitimate path depends on whether the SDK ever produces zero-condition deposits and whether such a payload is acceptable to the underlying SAC. Worth tracing.
+2. **PC-R-3 (no events on internal-only transacts).** This is intentional cost optimization but means the on-chain audit trail is shallower than auditors of typical smart contracts may expect.
+3. **CA-R-2/3 (no `set_admin` / `upgrade` events).** Combined with the inherited admin-sep traits, this means the audit trail for governance is partially implicit.
+4. **F-MANUAL-1 (signature-verifier wrappers).** Not currently exploitable but worth re-validating against any future Soroban SDK upgrade.
+5. **F-MANUAL-2 (zero-arg context bypass).** Code-structural rather than vulnerability; coupling that future refactors could break.
+6. **X-2 (shared admin compromise).** Architectural rather than code-level. The mitigation lives in the admin key's multi-sig configuration, which is off-contract.
+
+There are **no High residual risks** identified in this STRIDE pass that the form should flag as critical-severity findings to the audit firm. The Medium residuals (PC-R-3, CA-R-2/3, PC-E-4/5, X-2) are documented design choices or architectural realities; we describe them honestly here so that the audit firm can decide whether to dig deeper rather than discovering them mid-engagement.

--- a/contracts/testnet-readiness.md
+++ b/contracts/testnet-readiness.md
@@ -1,0 +1,137 @@
+# Soroban Core — Testnet Readiness Verification
+
+This document captures the evidence that the in-scope contracts are deployed and live on Stellar testnet, and that the local test suite is green from a fresh clone, satisfying the Audit Bank rule that applicants have "deployed [their contracts] on testnet" with extensive test coverage.
+
+Verification timestamp: 2026-05-08 (date of this PR).
+
+---
+
+## 1. Live testnet contracts
+
+The Tranche-1 D1 deliverable (delivered 2026-03-18 with `soroban-core` v0.1.0) deployed both contracts to Stellar testnet. Their addresses are stable and remain live:
+
+| Contract | Testnet contract ID | WASM hash | Created |
+|---|---|---|---|
+| Channel Auth | `CAF7DFHTPSYIW5543WBXJODZCDI5WF5SSHBXGMPKFOYPFRDVWFDNBGX7` | `8288c00d21403683e58993764f58dd3e21c3a9426c7f6106bdd022b331c3bfc1` | 2026-01-29 17:06:26 UTC |
+| Privacy Channel | `CDMZSHMT2AIL2UG7XBOHZKXM6FY3MUP75HAXUUSAHLGRQ2VWPGYKPM5T` | `5fd06369d23502139b36297a4ad6b0c6c9ef0df7021920ca10801fa9c2486e7c` | 2026-01-29 17:08:51 UTC |
+
+Both were deployed by the same Stellar account: `GB4EI6PC2MYRXX32R7ALCWAMSPNABWKSJBIWYIU2MUVQZHBMEMWBAO42`.
+
+### 1.1 Verification commands
+
+Verified via the public Stellar Expert API:
+
+```
+curl -sS https://api.stellar.expert/explorer/testnet/contract/CAF7DFHTPSYIW5543WBXJODZCDI5WF5SSHBXGMPKFOYPFRDVWFDNBGX7
+curl -sS https://api.stellar.expert/explorer/testnet/contract/CDMZSHMT2AIL2UG7XBOHZKXM6FY3MUP75HAXUUSAHLGRQ2VWPGYKPM5T
+```
+
+Raw responses (relevant fields only):
+
+**Channel Auth** —
+```json
+{
+  "contract":"CAF7DFHTPSYIW5543WBXJODZCDI5WF5SSHBXGMPKFOYPFRDVWFDNBGX7",
+  "creator":"GB4EI6PC2MYRXX32R7ALCWAMSPNABWKSJBIWYIU2MUVQZHBMEMWBAO42",
+  "wasm":"8288c00d21403683e58993764f58dd3e21c3a9426c7f6106bdd022b331c3bfc1",
+  "subinvocation":46,
+  "storage_entries":1
+}
+```
+
+The `subinvocation: 46` count reflects 46 occurrences of the contract being invoked as an authorization principal by other contracts — consistent with Channel Auth's role of governing one or more Privacy Channel deployments.
+
+**Privacy Channel** —
+```json
+{
+  "contract":"CDMZSHMT2AIL2UG7XBOHZKXM6FY3MUP75HAXUUSAHLGRQ2VWPGYKPM5T",
+  "creator":"GB4EI6PC2MYRXX32R7ALCWAMSPNABWKSJBIWYIU2MUVQZHBMEMWBAO42",
+  "wasm":"5fd06369d23502139b36297a4ad6b0c6c9ef0df7021920ca10801fa9c2486e7c",
+  "subinvocation":0,
+  "storage_entries":186
+}
+```
+
+`storage_entries: 186` reflects accumulated UTXO and instance-storage entries on testnet, consistent with bundles having been transacted against this channel during E2E testing.
+
+The `validation: { status: "unverified" }` field on both responses refers to Stellar Expert's *source-code attestation* (a separate program where contract authors upload the source for the explorer to display); it does not indicate any state inconsistency. The contracts themselves are live and reachable at the IDs given.
+
+### 1.2 RPC alternative
+
+If the auditor prefers a vendor-neutral path, the same contracts are reachable directly via Soroban testnet RPC:
+
+```
+curl -sS -X POST https://soroban-testnet.stellar.org \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"getContractData","params":{"contractId":"CAF7DFHTPSYIW5543WBXJODZCDI5WF5SSHBXGMPKFOYPFRDVWFDNBGX7","key":"LedgerKeyContractInstance"}}'
+```
+
+(Same call with the privacy-channel contract ID for that contract.)
+
+---
+
+## 2. Local test suite — green from a fresh clone
+
+This PR is being prepared from a fresh clone at `~/repos/tmp/audit-kickoff/soroban-core`. The full workspace test suite was run before drafting any of the audit-package documentation; it passes cleanly:
+
+```
+$ cargo test --workspace --no-fail-fast
+...
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 1m 18s
+```
+
+Per-crate results:
+
+| Crate | Tests passed | Failed | Ignored |
+|---|---|---|---|
+| `channel-auth-contract` | 5 | 0 | 0 |
+| `privacy-channel` | 2 | 0 | 0 |
+| `moonlight-auth` | 3 | 0 | 0 |
+| `moonlight-helpers` | 3 | 0 | 0 |
+| `moonlight-utxo-core` | 5 | 0 | 0 |
+| `moonlight-primitives` | 0 | 0 | 0 (no test target) |
+| `moonlight-storage` | 0 | 0 | 0 (no test target) |
+| `token-contract` (test-only) | 6 | 0 | 0 |
+| **Total in-scope contract + module** | **18** | **0** | **0** |
+
+A complete enumeration of which test covers which invariant is in `tests.md` §2.
+
+### 2.1 Toolchain used
+
+- `rustc` 1.94.0 (4a4ef493e 2026-03-02)
+- `cargo` 1.94.0 (85eff7c80 2026-01-15)
+- macOS arm64 (Darwin 25.4.0)
+
+### 2.2 Reproducing the run
+
+```
+git clone https://github.com/Moonlight-Protocol/soroban-core
+cd soroban-core
+cargo test --workspace --no-fail-fast
+```
+
+(The CI pipeline at `.github/workflows/pr.yml` runs the same command on every PR against `main`, plus the WASM build via `stellar contract build` and the cross-repo E2E + lifecycle suites in `Moonlight-Protocol/local-dev`.)
+
+---
+
+## 3. End-to-end testnet exercise
+
+Beyond the unit tests, the contracts are exercised end-to-end by `Moonlight-Protocol/local-dev`'s reusable Docker-Compose harness on every PR. The reusable workflows:
+
+- `Moonlight-Protocol/local-dev/.github/workflows/e2e-reusable.yml` — full deposit / transfer / withdraw lifecycle including the provider-platform mempool, executor, verifier, and a real Stellar local instance.
+- `Moonlight-Protocol/local-dev/.github/workflows/lifecycle-reusable.yml` — multi-cycle deposit + transfer + withdraw flow with provider restarts and observability checks.
+
+Both are wired in via `soroban-core/.github/workflows/pr.yml` (`e2e:` and `lifecycle:` jobs that consume the `contract-wasms` artifact uploaded by the build step). On `main`, a successful tag push (auto-triggered by `auto-tag.yml` on any `Cargo.toml` change) emits a `repository_dispatch` (`event-type: module-release`) to `local-dev` to re-run integration tests across the rest of the Moonlight stack against the new release.
+
+The 46 `subinvocation` count on Channel Auth and 186 `storage_entries` on Privacy Channel (per §1.1) reflect the cumulative effect of these E2E suites running against testnet over the period from 2026-01-29 (deploy date) through 2026-05-08 (this verification).
+
+---
+
+## 4. Out-of-band evidence
+
+The deployed testnet state is independently visible to the auditor through the public-facing consoles (out of audit scope, but provided as confirmation):
+
+- Council Console — `https://moonlight-council-console.fly.storage.tigris.dev`
+- Network Dashboard — `https://network-dashboard.fly.storage.tigris.dev`
+
+The Network Dashboard surfaces live channel state (supply, provider count, channel asset) for every Privacy Channel governed by every Channel Auth visible from the public Stellar testnet event stream.

--- a/contracts/tests.md
+++ b/contracts/tests.md
@@ -1,0 +1,284 @@
+# Soroban Core — Test Coverage and Testnet Evidence
+
+This document describes the existing test surface for the in-scope contracts and identifies coverage gaps. It is intended to give the auditor a map of what has and has not been exercised, so the audit firm can scope their own coverage work accordingly.
+
+The Audit Bank intake form asks for "previous security practices" and a remediation plan; we are explicit about gaps here rather than overclaiming.
+
+---
+
+## 1. Test layout
+
+```
+contracts/channel-auth/src/tests/
+  mod.rs                  — test entry
+  tests.rs                — end-to-end auth + UTXO transact path
+  events.rs               — event emission assertions
+
+contracts/privacy-channel/src/test/
+  mod.rs                  — test entry
+  test.rs                 — deposit + transfer happy paths
+  channel_operation_builder.rs — test helper (not a test file itself)
+
+modules/utxo-core/src/tests/
+  mod.rs
+  test.rs                 — UTXO accounting unit + bundle tests
+
+modules/auth/src/test.rs  — provider/UTXO auth + signature verification
+
+modules/helpers/src/tests.rs — strkey/Address roundtrip
+```
+
+All tests are Rust unit tests run via `cargo test` from the workspace root. There is no separate integration-test crate. The `local-dev` repo's Docker-based E2E suites exercise the deployed-contract surface; those are described in §4.
+
+---
+
+## 2. What each test covers
+
+### 2.1 `contracts/channel-auth/`
+
+#### `tests/tests.rs::test_auth_module`
+
+Full happy-path validation of the auth contract acting as the authorization principal for a UTXO contract.
+
+- Constructs `ChannelAuthContract` with a fresh admin (mocked Address).
+- Constructs an in-test UTXO contract from `moonlight-utxo-core::testutils::contract` and binds it to the auth contract.
+- Asserts `admin()` and `auth()` getters are correctly initialized.
+- Adds a provider via `add_provider` with mocked admin auth; asserts `is_provider == true`.
+- Mints two UTXOs via the test-only `mint` helper.
+- Constructs a `UTXOOperation` that spends both UTXOs and creates two new ones.
+- Each spend UTXO signs its conditions with its own P256 key.
+- The provider signs the bundle's auth-entry payload hash with Ed25519.
+- Submits via `client.set_auths(...)` and asserts both spent UTXOs are zero and both created UTXOs hold their expected balance.
+
+**Invariants exercised:** CA-2 (provider threshold), CA-3 (expiration check, implicitly — uses `current + 1`), CA-4 (P256 coverage), CA-7 (event emission for `add_provider`, asserted in `events.rs`), PC-5/6/7 (UTXO uniqueness and dedup, indirectly via the underlying utxo-core).
+
+#### `tests/events.rs`
+
+Three event-emission tests:
+
+- `test_constructor_emits_initialized_event` — asserts `contract_initialized(admin)` is the last event after construction.
+- `test_add_provider_emits_event` — asserts `provider_added(provider)` after `add_provider`.
+- `test_remove_provider_emits_event` — asserts `provider_removed(provider)` after `remove_provider`.
+- `test_provider_lifecycle_with_events` — adds then removes a provider and asserts both `is_provider` transitions.
+
+**Invariants exercised:** CA-7.
+
+### 2.2 `contracts/privacy-channel/`
+
+#### `test/test.rs::test_single_deposit_with_auth`
+
+Single-depositor smoke. Adds a provider; mints a token balance to a Stellar G-account ("john"); deposits 500 tokens into the channel under the condition `Create(utxo_a, 500)`; asserts:
+
+- `john`'s token balance decreased by 500.
+- Channel `supply()` is 500.
+- `utxo_a` balance is 500.
+
+The deposit is signed by `john` via `sign_for_transaction` and the bundle is signed by `provider_a`. The flow constructs a real `xdr::SorobanAuthorizationEntry` for the depositor's auth, exercising the full Soroban auth-entry signing path (not `mock_all_auths`).
+
+**Invariants exercised:** PC-3 (supply ↔ external flow), PC-4 (bundle balance with no spends), PC-13 (depositor consent), CA-2 (provider threshold), CA-4 (no P256 spends, but the AuthRequirements arg is empty so the check is a no-op).
+
+#### `test/test.rs::test_auth_module`
+
+Multi-deposit + multi-spend transfer lifecycle.
+
+- Initializes channel + auth + token + admin.
+- Asserts construction-time getters match (admin, auth, asset, supply == 0).
+- Asserts `try_add_provider` without admin auth fails.
+- Adds two providers under admin auth.
+- Mints to `john` and `jane`; asserts balances.
+- Deposits from both `john` (500 → 200+300 across utxo_a, utxo_c) and `jane` (600 → 300+300 across utxo_b, utxo_d) under matching `Create` conditions; asserts post-deposit balances match.
+- Channel supply == 1100; UTXO balances match condition amounts.
+- Sets ledger sequence to 3; constructs a transfer-only bundle (no deposit/withdraw) that spends all four UTXOs and creates five new ones with the original ones' conditions; asserts post-transfer balances and that supply is unchanged.
+
+**Invariants exercised:** CA-1 (provider mutation gated on admin), CA-4 (P256 sigs for all four spends), PC-3 (supply unchanged on internal-only transfer), PC-4 (bundle balance), PC-5/6 (UTXO state transitions), PC-13 (depositor consent for both addresses).
+
+**Coverage gap noted in this file:** the comment at `test.rs:96` says "no conditions as we cant properly test the G address signing mixed with the mocked address" — i.e. the team is aware that some auth-mixing scenarios remain difficult to exercise inside the Soroban test harness.
+
+### 2.3 `modules/auth/`
+
+#### `test.rs::test_auth_module`
+
+Mirror of `contracts/channel-auth/tests/tests.rs::test_auth_module` but at the module level, against an in-test wrapper contract that surfaces `ProviderAuthorizable` and `UtxoAuthorizable`. Same invariants exercised.
+
+#### `test.rs::test_auth_module_errors`
+
+Negative-path test for the expiration check.
+
+- Sets `e.ledger().set_sequence_number(10)`.
+- Issues a signature with `expired_live_until_ledger = 9`.
+- Submits; asserts `try_transact` returns the Soroban host's `Context::InvalidAction` error.
+- Note: the comment at lines 167-175 acknowledges that the contract's structured `SignatureExpired` error is wrapped by the Soroban host's auth-failure handling, so the inner contract error is not directly observable from outside `__check_auth`. The test settles for asserting the outer `InvalidAction`.
+
+**Invariants exercised:** CA-3.
+
+#### `test.rs::test_ed25519_signatures`
+
+Unit test for the `verify_signature` dispatch. Generates an Ed25519 keypair, signs a known payload, populates a `SignerKey::Ed25519 → (Signature::Ed25519, u32::MAX)` map, and round-trips through `verify_signature`. Mostly validates the mapping pattern in `core::verify_signature` rather than auth flow proper.
+
+### 2.4 `modules/utxo-core/`
+
+#### `tests/test.rs::test_mint_and_burn`
+
+UTXO state machine fundamentals:
+
+- Non-existing UTXO returns -1.
+- After mint, balance equals the minted amount.
+- After burn, balance is 0.
+- Re-minting an existing UTXO errors `UTXOAlreadyExists`.
+- Burning an already-spent UTXO errors `UTXOAlreadySpent`.
+- Burning a never-existed UTXO errors `UTXODoesntExist`.
+- Minting with negative amount errors `InvalidCreateAmount`.
+- Minting with zero amount errors `InvalidCreateAmount`.
+
+**Invariants exercised:** PC-5, PC-6, PC-8.
+
+#### `tests/test.rs::test_transfer`
+
+Full bundle lifecycle:
+
+- Mint utxo_a 250.
+- Transfer (spend utxo_a, create utxo_b 250) succeeds; balances flip.
+- Bundle with duplicate creates errors `RepeatedCreateUTXO`.
+- Bundle with duplicate spends errors `RepeatedSpendUTXO`.
+- Unbalanced bundle (550 in, 500 out) errors `UnbalancedBundle`.
+- Balanced bundle (550 in, 550 out across multiple creates) succeeds.
+
+**Invariants exercised:** PC-4, PC-7.
+
+#### `tests/test.rs::test_transfer_auth_mocked`
+
+Auth-failure paths around the `auth.require_auth_for_args` site:
+
+- Bundle with valid structure but no auth → outer `Context::InvalidAction`.
+- Bundle with a `set_auths` entry but a `false` mock signature → outer `Context::InvalidAction`.
+- Bundle with `true` mock signature → succeeds.
+
+**Invariants exercised:** CA-4 surrogate (the actual P256 check is mocked here; this test verifies the Soroban auth-entry plumbing).
+
+#### `tests/test.rs::test_transfer_with_external`
+
+Tests the `transact_with_external(op, additional_in, additional_out)` test-only entry point that exposes the bundle-balance contract directly, without going through the Privacy Channel's `transact`. Validates that:
+
+- A bundle that needs additional_in but is given 0 → `UnbalancedBundle`.
+- A bundle that needs additional_out but is given 0 → `UnbalancedBundle`.
+- Passing the correct values → succeeds.
+
+**Invariants exercised:** PC-4 (bundle balance equation with non-zero deposit/withdraw totals).
+
+#### `tests/test.rs::test_transfer_with_additional_auth_conditions`
+
+Tests that a bundle with `Condition::ExtDeposit`, `ExtWithdraw`, and `ExtIntegration` entries inside its spend conditions affects the auth requirements (the `AuthRequirements` map keyed by P256 signers includes those conditions) but does not affect the balance equation. The test uses `transact_with_external` to supply the deposit/withdraw totals manually since this test is at the utxo-core layer, not the Privacy Channel layer.
+
+**Invariants exercised:** auth payload construction includes Ext* conditions; balance equation is independent of auth-conditions content.
+
+### 2.5 `modules/helpers/`
+
+#### `tests.rs::roundtrip_pk_to_address_and_back`
+
+Asserts `address_from_ed25519_pk_bytes` and `address_to_ed25519_pk_bytes` are mutually inverse for a hardcoded 32-byte key.
+
+#### `tests.rs::address_string_roundtrip_works`
+
+Same, starting from a `Strkey` string.
+
+#### `tests.rs::start_from_address_string`
+
+Same, starting from a known `G…` Stellar address string.
+
+These are correctness checks for the strkey conversion path used by `require_provider` to look up provider addresses.
+
+---
+
+## 3. Coverage gaps
+
+The following invariants from `arch.md` are *not* directly exercised by the existing test suite, or are exercised only indirectly. We document them honestly here; remediation (closing these gaps) is out of scope for this PR and is dispatched as a separate prompt.
+
+### 3.1 Direct gaps in invariant coverage
+
+| Invariant | Gap |
+|---|---|
+| **CA-2 (provider threshold)** | Only the success path is tested. There is no negative test for *zero* provider signatures (i.e., a bundle submitted with only P256 sigs and no provider sig should error `ProviderThresholdNotMet`). Worth adding. |
+| **CA-3 (expiration)** | Tested for the all-signatures-expired case in `auth/test.rs::test_auth_module_errors`. Not tested for *partial* expiration (e.g., one P256 sig expired but provider sig fresh, or vice versa). Worth adding. |
+| **CA-5 (context shape)** | No test exercises a non-`Contract` context to verify `UnexpectedContext` is raised. Likely difficult to set up via the Soroban test harness. |
+| **CA-6 (signature/key match)** | No test mismatches a P256 SignerKey with an Ed25519 Signature (or vice versa) to verify `InvalidSignatureFormat`. Worth adding. |
+| **PC-1 (immutable asset binding)** | No test attempts to overwrite the asset address post-construction. Code structure does not expose a setter, so the gap is structural rather than behavioral, but a regression test guarding against a future `set_asset` accidentally being added would be cheap. |
+| **PC-2 (immutable auth binding)** | Same as PC-1: no setter exposed; no regression test. |
+| **PC-9 (no duplicate addresses externally)** | No test submits a `ChannelOperation` with two `(Address, _, _)` deposit entries for the same address; the `RepeatedAccountForDeposit` and `RepeatedAccountForWithdraw` errors do not have direct test coverage. |
+| **PC-10 (cross-side condition equality)** | The test-only `ChannelOperationBuilder` enforces this via `panic!` at construction time (`channel_operation_builder.rs:77-82`), but the on-chain `ConflictingConditionsForAccount` error itself is not exercised by a test that submits to `transact`. |
+| **PC-11 (no condition conflicts)** | `BundleHasConflictingConditions` error has no direct test that submits a bundle with `Create(u, 100)` on one spend and `Create(u, 200)` on another. |
+| **PC-12 (overflow safety on totals)** | `AmountOverflow` is not exercised. Hard to trigger naturally (requires `i128::MAX`-class amounts), but a unit test with crafted inputs would document the path. |
+| **Drawer rotation** | The bitmap drawer (`storage-drawer`) tests rotate at 1024 slots. No test pushes the slot allocator past `SLOTS_PER_DRAWER` to exercise the rotation+flush path in `alloc_slot_and_rotate_if_needed_cached`. The team should consider a stress test minting >1024 UTXOs in a session. |
+| **Storage backend swap** | All tests run with the workspace-default backend (`storage-drawer`). The `storage-simple` backend is compile-checked but not exercised end-to-end. |
+| **Upgrade path** | `Upgradable::upgrade(wasm_hash)` from `admin-sep` is not exercised by any in-tree test. The pattern is admin-gated and inherited from a trusted base, but the lack of a regression test means any locally-introduced override would not be caught. |
+| **`set_admin` event** | There is no event emitted on `set_admin`; this is documented as an invariant gap in arch §4.1, not a test gap. |
+
+### 3.2 Test-mocking caveats
+
+- Most provider-add and admin-action tests use `mock_auths` rather than constructing real Stellar auth entries. This is appropriate for unit testing but means the auth-entry XDR shape is only exercised through the Soroban test framework's mocking layer, not against a real Stellar host. The `privacy-channel::test_single_deposit_with_auth` and `test_auth_module` tests do construct real auth entries for the *deposit* path (via `xdr::SorobanAuthorizationEntry`), which is the most production-realistic surface in the suite.
+- The provider-only auth path against a real auth-entry XDR (no `mock_auths`) is exercised by the multi-utxo cases in `auth/test.rs::test_auth_module` and `channel-auth/tests/tests.rs::test_auth_module`.
+- The Soroban host wraps inner `__check_auth` errors in `ScErrorType::Context, ScErrorCode::InvalidAction`, so the existing tests cannot directly assert which inner contract error fired. The team's `test_auth_module_errors` comment (`auth/test.rs:167-175`) acknowledges this.
+
+### 3.3 Coverage tools not yet wired
+
+- No `cargo tarpaulin` / `cargo-llvm-cov` line-coverage report is generated by CI. There is no enforced minimum coverage threshold. Adding line-coverage measurement is a small lift and would help future-proof the suite; out of scope here.
+- No fuzz testing or property-based testing. The bundle-balance equation (PC-4) is a natural target for property-based testing (`proptest`); the condition-conflict logic is another. Out of scope.
+
+---
+
+## 4. Testnet evidence
+
+Per SCF #37 D1 (delivered 2026-03-18 with `soroban-core` v0.1.0), both contracts are deployed on Stellar **testnet** with the following IDs:
+
+| Contract | Testnet contract ID |
+|---|---|
+| Channel Auth | `CAF7DFHTPSYIW5543WBXJODZCDI5WF5SSHBXGMPKFOYPFRDVWFDNBGX7` |
+| Privacy Channel | `CDMZSHMT2AIL2UG7XBOHZKXM6FY3MUP75HAXUUSAHLGRQ2VWPGYKPM5T` |
+
+Verification of these IDs is captured separately in `testnet-readiness.md`.
+
+### 4.1 End-to-end exercise outside cargo test
+
+Beyond the in-repo unit tests, the contracts are exercised end-to-end by the Moonlight `local-dev` repository:
+
+- **E2E suite** (`local-dev/.github/workflows/e2e-reusable.yml`): consumed by this repo's `pr.yml` workflow on every pull request. The `e2e` job runs against the freshly built contract WASMs uploaded as the `contract-wasms` artifact and exercises the full provider-platform → channel deposit/transfer/withdraw lifecycle.
+- **Lifecycle suite** (`local-dev/.github/workflows/lifecycle-reusable.yml`): also consumed by `pr.yml`. Validates a longer-running deposit → transfer → withdraw cycle including provider-platform restart and observability checks.
+- **Cross-repo dispatch** (`release.yml`): on tag push (auto-tag triggers on `Cargo.toml` change), the WASMs are released to GitHub and a `repository_dispatch` is sent to `local-dev` with `event-type: module-release`, which kicks off integration tests across the rest of the stack against the new release.
+
+Net effect: every commit to `main` of `soroban-core` runs through E2E and lifecycle suites against a Dockerized stack that includes the provider-platform, browser-wallet, and a real local Stellar instance. This is the strongest evidence we have that the contracts are exercised end-to-end against realistic conditions.
+
+### 4.2 Public testnet console references
+
+The deployed testnet contracts are also referenced from the public-facing consoles:
+
+- Council Console: `https://moonlight-council-console.fly.storage.tigris.dev`
+- Network Dashboard: `https://network-dashboard.fly.storage.tigris.dev`
+
+These are out of audit scope but are linked here so the auditor can independently inspect the live testnet state.
+
+---
+
+## 5. Tooling and reproducibility
+
+To re-run the contract test suite locally against this repo:
+
+```
+git clone https://github.com/Moonlight-Protocol/soroban-core
+cd soroban-core
+cargo test --workspace
+```
+
+Build the deployable WASMs with:
+
+```
+stellar contract build
+```
+
+The CI build (`pr.yml`) uses:
+
+- Rust toolchain: `dtolnay/rust-toolchain@stable`, target `wasm32v1-none`.
+- Soroban CLI: `cargo install --locked --force stellar-cli` (latest).
+- System deps: `pkg-config libdbus-1-dev libudev-dev` (Ubuntu).
+
+Per-test runtime is dominated by the Soroban test-host setup; the full workspace test suite typically completes in under a minute on a modern laptop.
+
+Versions and pin hashes are documented exhaustively in `arch.md` §7.


### PR DESCRIPTION
## Why this PR exists

This PR ships the documentation package the [SDF Soroban Security Audit Bank](https://stellar.gitbook.io/scf-handbook/supporting-programs/audit-bank/official-rules) intake form requires. It is the SCF #37 Tranche 3 D7 (Security Audit and Remediation) gating step — D7 is the only audit channel the grant permits, and clearing the readiness review on the first pass requires a strong package up front.

Audit scope per D7: smart contracts only — `contracts/channel-auth/` and `contracts/privacy-channel/`. Platforms, frontends, SDK, and infra are out of scope.

## What's in this PR

Five new docs under `contracts/`:

- **`arch.md`** — Protocol overview, per-contract responsibilities, public interfaces, persistent state model, key events, exhaustive invariants (CA-1..CA-7 for Channel Auth, PC-1..PC-15 for Privacy Channel, X-1/X-2 cross-contract), trust boundaries, out-of-scope notes, and the toolchain pin (Rust 2021 / `wasm32v1-none` / Soroban SDK at `AhaLabs/rs-soroban-sdk` rev `5a99659f` / admin-sep at `AhaLabs/admin-sep` rev `bf195f4d`).
- **`tests.md`** — Per-test coverage map across `contracts/channel-auth/`, `contracts/privacy-channel/`, and the `modules/{auth,utxo-core,helpers}` test surfaces; an honest list of coverage gaps (the invariants not directly exercised) with the rationale for deferring closure to a follow-up prompt; D1 testnet contract IDs; reproduce-locally instructions.
- **`static-analysis.md`** — `cargo-audit` 0.22.1 over the workspace `Cargo.lock` (0 vulnerabilities, 3 unmaintained-crate advisories: `derivative`, `paste`, `wee_alloc`) and `cargo-clippy` with `clippy::all` + `clippy::pedantic` (0 errors, 307 warnings — 17 are `missing_panics_doc` and audit-relevant; the rest are stylistic). 7 manual code-walk notes capturing non-obvious code-structure couplings (signature-verifier wrappers, zero-arg context bypass, `panic!` vs `panic_with_error!` inconsistency, etc.). Per-finding remediation plan.
- **`stride.md`** — Full STRIDE threat model. Likelihood / impact / mitigation / residual-risk per scenario, per category, per contract. Residual-risk summary lists Medium-residuals (no Highs) and the items the team flags as most deserving of the audit firm's deeper look.
- **`testnet-readiness.md`** — Live-contract verification via Stellar Expert API for both D1 contract IDs (Channel Auth `CAF7…` and Privacy Channel `CDMZ…`) confirming WASM hashes and accumulated state, plus the local `cargo test --workspace` green output (24/24 passing).

## Static-analysis findings — count and remediation

- **0** vulnerabilities (cargo-audit).
- **3** unmaintained-crate advisories (informational): `derivative` / `paste` (transitive via Soroban SDK; track upstream upgrades) and `wee_alloc` (direct global allocator; tracked as a post-audit cleanup PR).
- **0** clippy errors. **307** clippy pedantic warnings; 17 are audit-relevant `missing_panics_doc` gaps to be closed in a doc-only follow-up; the remainder are pure style.
- **7** manual code-walk informational notes.

No critical / high / medium findings to remediate before audit. Detail in `contracts/static-analysis.md`.

## STRIDE residuals (full breakdown in `contracts/stride.md`)

- No High residuals across either contract.
- Medium residuals: PC-T-3 (deposit with empty conditions list — boundary worth tracing), PC-R-3 (no contract events on internal-only `transact`, by design — privacy/cost optimization), CA-R-2/3 (no events on `set_admin` / `upgrade`), PC-E-4/5 (admin-can-upgrade to malicious WASM; admin-can-be-provider — both architectural), X-2 (shared Channel Auth admin compromises all bound channels — architectural, mitigated by Stellar-native multisig on the admin address).

## Test plan

- [x] `cargo test --workspace --no-fail-fast` — 24/24 passing (results captured in `contracts/testnet-readiness.md` §2).
- [x] `cargo audit` — 0 vulnerabilities, 3 informational unmaintained advisories.
- [x] `cargo clippy --workspace --no-deps --all-targets -- -W clippy::all -W clippy::pedantic` — 0 errors.
- [x] Both D1 testnet contract IDs verified live via Stellar Expert API.
- [x] No contract code changes; existing CI (PR build + cross-repo E2E + lifecycle suites) should be unaffected.

## Out of scope (separate prompts)

- Fixing any of the static-analysis or STRIDE findings (each is captured in the remediation plan; none is critical/high/medium).
- Closing the test coverage gaps documented in `tests.md` §3.
- Filling out the actual Audit Bank intake form (PM does this using these artifacts).