### PR TITLE
docs: rename AhaLabs → theahaco in audit-package docs

### DIFF
--- a/contracts/arch.md
+++ b/contracts/arch.md
@@ -67,7 +67,7 @@ Source of truth: `contracts/channel-auth/src/contract.rs`.
 | `upgrade(wasm_hash)` | admin | `wasm_hash: BytesN<32>` | — | From `admin-sep::Upgradable`. Replaces contract WASM. |
 | `__check_auth(payload, signatures, contexts)` | Soroban host | `payload: Hash<32>`, `signatures: Signatures`, `contexts: Vec<Context>` | `Result<(), Error>` | Auth entry point invoked by Soroban when this contract is named as an authorization principal. |
 
-The `Administratable` and `Upgradable` traits are pulled from the AhaLabs fork of `admin-sep` (workspace dep, rev `bf195f4`). They provide standard admin-gated patterns and require admin auth at the entry point.
+The `Administratable` and `Upgradable` traits are pulled from the theahaco fork of `admin-sep` (workspace dep, rev `bf195f4`). They provide standard admin-gated patterns and require admin auth at the entry point.
 
 ### 2.3 Persistent state (instance storage)
 
@@ -382,8 +382,8 @@ Auditors may reasonably assume the following are part of the audit; they are not
 - **The browser-wallet, council-console, provider-console, network-dashboard**: front-end applications. Out of scope.
 - **The local-dev** orchestration repo: Docker Compose harness for E2E testing. Provides regression evidence (see `tests.md`) but its own code is not in audit scope.
 - **The `contracts/token/` test token**: a workspace-internal token used only in `privacy-channel` integration tests. Not deployed.
-- **The `admin-sep` crate** (`AhaLabs/admin-sep`): pulled in via git, rev `bf195f4d67cc96587974212f998680ccf9a61cd7`. Provides `Administratable` and `Upgradable` traits. Auditors should treat its behavior as part of the trusted base; if a deeper audit of `admin-sep` is desired, that is a separate scope.
-- **The Soroban SDK fork** (`AhaLabs/rs-soroban-sdk`, rev `5a99659f1483c926ff87ea45f8823b8c00dc4cbd`): the workspace pins a specific revision of an Aha-maintained fork rather than `stellar/rs-soroban-sdk`. Where this fork diverges from upstream is itself worth review, but the SDK code is not in this audit scope. Auditors should be aware of the fork pin and may want to ask for the diff against upstream.
+- **The `admin-sep` crate** (`theahaco/admin-sep`): pulled in via git, rev `bf195f4d67cc96587974212f998680ccf9a61cd7`. Provides `Administratable` and `Upgradable` traits. Auditors should treat its behavior as part of the trusted base; if a deeper audit of `admin-sep` is desired, that is a separate scope.
+- **The Soroban SDK fork** (`theahaco/rs-soroban-sdk`, rev `5a99659f1483c926ff87ea45f8823b8c00dc4cbd`): the workspace pins a specific revision of an Aha-maintained fork rather than `stellar/rs-soroban-sdk`. Where this fork diverges from upstream is itself worth review, but the SDK code is not in this audit scope. Auditors should be aware of the fork pin and may want to ask for the diff against upstream.
 - **Stellar Asset Contract** behavior: the channel trusts its configured asset SAC to enforce its own transfer semantics. Custom non-SAC assets are not a tested path.
 
 ---
@@ -394,8 +394,8 @@ Captured here so readers do not need to grep the workspace.
 
 - **Rust edition:** 2021 (workspace).
 - **WASM target:** `wasm32v1-none` (Soroban-supported target; `release.yml` builds against this).
-- **Soroban SDK:** git pin `https://github.com/AhaLabs/rs-soroban-sdk` rev `5a99659f1483c926ff87ea45f8823b8c00dc4cbd`.
-- **`admin-sep`:** git pin `https://github.com/AhaLabs/admin-sep` rev `bf195f4d67cc96587974212f998680ccf9a61cd7`.
+- **Soroban SDK:** git pin `https://github.com/theahaco/rs-soroban-sdk` rev `5a99659f1483c926ff87ea45f8823b8c00dc4cbd`.
+- **`admin-sep`:** git pin `https://github.com/theahaco/admin-sep` rev `bf195f4d67cc96587974212f998680ccf9a61cd7`.
 - **`stellar-default-impl-macro`:** git pin `https://github.com/OpenZeppelin/stellar-contracts` tag `v0.3.0`.
 - **`wee_alloc`:** workspace dep version 0.4 (used as `#[global_allocator]` for `wasm32` builds).
 - **Build command (CI):** `stellar contract build` (latest `stellar-cli`, locked install).

--- a/contracts/static-analysis.md
+++ b/contracts/static-analysis.md
@@ -50,7 +50,7 @@ warning: 3 allowed warnings found
 
 **Remediation plan:** **Out of scope for this PR; accept-and-track.**
 
-The dependency arrives through the Soroban SDK pin (`AhaLabs/rs-soroban-sdk`, rev `5a99659f…`). Replacing or upgrading `derivative` would require either an upstream upgrade in the Soroban SDK or a fork. The advisory is informational; the crate has no known security vulnerability — the maintainer simply stopped accepting changes. We will track upstream SDK updates and pick up a fix whenever the Soroban SDK does. No on-chain risk to the contracts in the meantime.
+The dependency arrives through the Soroban SDK pin (`theahaco/rs-soroban-sdk`, rev `5a99659f…`). Replacing or upgrading `derivative` would require either an upstream upgrade in the Soroban SDK or a fork. The advisory is informational; the crate has no known security vulnerability — the maintainer simply stopped accepting changes. We will track upstream SDK updates and pick up a fix whenever the Soroban SDK does. No on-chain risk to the contracts in the meantime.
 
 #### F-AUDIT-2 — `paste 1.0.15` (unmaintained)
 
@@ -169,7 +169,7 @@ fn verify_ed25519_signature(...) -> Result<(), Error> {
 }
 ```
 
-Both wrappers always return `Ok(())`. They depend on the underlying Soroban host primitives panicking on a failed verification. This is the documented behavior of `secp256r1_verify` and `ed25519_verify` in the Soroban SDK at the pinned revision (`5a99659f…` of `AhaLabs/rs-soroban-sdk`).
+Both wrappers always return `Ok(())`. They depend on the underlying Soroban host primitives panicking on a failed verification. This is the documented behavior of `secp256r1_verify` and `ed25519_verify` in the Soroban SDK at the pinned revision (`5a99659f…` of `theahaco/rs-soroban-sdk`).
 
 **Implication:** if the upstream SDK ever changes these primitives to return a `Result` rather than panic, the wrappers as written would silently accept invalid signatures. This is not a current vulnerability but is a non-obvious coupling worth documenting and worth re-validating against any future SDK upgrade.
 


### PR DESCRIPTION
## Summary

Renames `AhaLabs` → `theahaco` in `contracts/arch.md` (5 occurrences) and `contracts/static-analysis.md` (2 occurrences) so the audit-package docs match the now-clean Cargo.toml dep URLs.

Cargo.toml was updated separately to point at theahaco URLs (with a `[patch]` redirect for the transitive ahalabs ref inside admin-sep@bf195f4d). These two `.md` files were not updated in that PR; this PR closes that consistency gap before the audit firm reads the package.

No content changes beyond the URL/org rename. Same SHAs, same dependency tree shape, same audit-relevant statements.

## Test plan

- [x] `grep -i ahalabs contracts/arch.md contracts/static-analysis.md` → 0 matches
- [x] No code changes; CI should pass build + e2e + lifecycle as on main