### PR TITLE
fix(security): remediate preemptive audit findings (MOON-01..10)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ authors = ["Moonlight"]
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/Moonlight-Protocol/soroban-core"
-version = "0.2.0"
+version = "0.2.1"
 
 
 [workspace.dependencies]

--- a/contracts/channel-auth/src/contract.rs
+++ b/contracts/channel-auth/src/contract.rs
@@ -34,10 +34,23 @@ pub struct ChannelAuthContract;
 
 impl UtxoAuthorizable for ChannelAuthContract {}
 
+// MOON-02: instance-storage holds the provider set and owner; bump its TTL on construction and on
+// every auth check (which happens on every governed bundle) so it cannot archive while in use.
+const DAY_IN_LEDGERS: u32 = 17_280;
+const INSTANCE_BUMP_AMOUNT: u32 = 7 * DAY_IN_LEDGERS;
+const INSTANCE_LIFETIME_THRESHOLD: u32 = INSTANCE_BUMP_AMOUNT - DAY_IN_LEDGERS;
+
+fn bump_instance_ttl(e: &Env) {
+    e.storage()
+        .instance()
+        .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+}
+
 #[contractimpl]
 impl ChannelAuthContract {
     pub fn __constructor(env: &Env, admin: &Address) {
         ownable::set_owner(env, admin);
+        bump_instance_ttl(env);
         ContractInitialized {
             admin: admin.clone(),
         }
@@ -96,6 +109,7 @@ impl CustomAccountInterface for ChannelAuthContract {
         signatures: Signatures, // provided by tx submitter in Authorization entry
         contexts: Vec<Context>, // require_auth_for_args
     ) -> Result<(), MoonlightError> {
+        bump_instance_ttl(&e);
         Self::require_provider(&e, payload, signatures.clone())?;
         Self::handle_utxo_auth(&e, signatures.clone(), contexts)
     }

--- a/contracts/channel-auth/src/contract.rs
+++ b/contracts/channel-auth/src/contract.rs
@@ -29,6 +29,14 @@ pub struct ProviderRemoved {
     pub provider: Address,
 }
 
+// MOON-09: emit a dedicated event on upgrade so the governance audit trail does not rely solely on
+// the raw Stellar transaction record.
+#[contractevent(data_format = "single-value")]
+pub struct Upgraded {
+    #[topic]
+    pub wasm_hash: BytesN<32>,
+}
+
 #[contract]
 pub struct ChannelAuthContract;
 
@@ -71,6 +79,10 @@ impl ChannelAuthContract {
 
     pub fn upgrade(e: &Env, wasm_hash: BytesN<32>) {
         ownable::enforce_owner_auth(e);
+        Upgraded {
+            wasm_hash: wasm_hash.clone(),
+        }
+        .publish(e);
         upgradeable::upgrade(e, &wasm_hash);
     }
 }

--- a/contracts/privacy-channel/src/contract.rs
+++ b/contracts/privacy-channel/src/contract.rs
@@ -1,5 +1,8 @@
+use moonlight_errors::Error;
 use moonlight_utxo_core::core::UtxoHandlerTrait;
-use soroban_sdk::{contract, contractimpl, Address, BytesN, Env, Vec};
+use soroban_sdk::{
+    contract, contractimpl, panic_with_error, symbol_short, Address, BytesN, Env, Symbol, Vec,
+};
 use stellar_access::ownable;
 use stellar_contract_utils::upgradeable;
 
@@ -23,6 +26,23 @@ fn bump_instance_ttl(e: &Env) {
     e.storage()
         .instance()
         .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+}
+
+// MOON-06: reentrancy guard. `transact` makes external SAC calls (deposit pull / withdraw push);
+// a non-standard or malicious asset could call back into `transact`. The guard is a transient flag
+// that is set on entry and cleared on exit; a re-entrant call observes it and reverts. (On revert
+// the transient write is rolled back, so the flag never persists across transactions.)
+const REENTRANCY_GUARD: Symbol = symbol_short!("RGUARD");
+
+fn enter_reentrancy_guard(e: &Env) {
+    if e.storage().temporary().has(&REENTRANCY_GUARD) {
+        panic_with_error!(e, Error::ReentrantCall);
+    }
+    e.storage().temporary().set(&REENTRANCY_GUARD, &true);
+}
+
+fn exit_reentrancy_guard(e: &Env) {
+    e.storage().temporary().remove(&REENTRANCY_GUARD);
 }
 
 #[contractimpl]
@@ -74,6 +94,7 @@ impl PrivacyChannelContract {
 
     pub fn transact(e: Env, op: ChannelOperation) {
         bump_instance_ttl(&e);
+        enter_reentrancy_guard(&e);
 
         let (utxo_op, total_deposit, total_withdraw) =
             pre_process_channel_operation(&e, op.clone());
@@ -81,5 +102,7 @@ impl PrivacyChannelContract {
         Self::process_bundle(&e, utxo_op.clone(), total_deposit, total_withdraw);
 
         execute_external_operations(&e, op.deposit, op.withdraw);
+
+        exit_reentrancy_guard(&e);
     }
 }

--- a/contracts/privacy-channel/src/contract.rs
+++ b/contracts/privacy-channel/src/contract.rs
@@ -13,6 +13,18 @@ pub struct PrivacyChannelContract;
 
 impl UtxoHandlerTrait for PrivacyChannelContract {}
 
+// MOON-02: instance-storage holds the asset/auth bindings, supply, and owner; bump its TTL on
+// every mutating entrypoint so the contract instance cannot archive out from under live channels.
+const DAY_IN_LEDGERS: u32 = 17_280;
+const INSTANCE_BUMP_AMOUNT: u32 = 7 * DAY_IN_LEDGERS;
+const INSTANCE_LIFETIME_THRESHOLD: u32 = INSTANCE_BUMP_AMOUNT - DAY_IN_LEDGERS;
+
+fn bump_instance_ttl(e: &Env) {
+    e.storage()
+        .instance()
+        .extend_ttl(INSTANCE_LIFETIME_THRESHOLD, INSTANCE_BUMP_AMOUNT);
+}
+
 #[contractimpl]
 impl PrivacyChannelContract {
     pub fn __constructor(e: &Env, admin: Address, auth_contract: Address, asset: Address) {
@@ -20,6 +32,7 @@ impl PrivacyChannelContract {
         ownable::enforce_owner_auth(e);
         <Self as UtxoHandlerTrait>::set_auth(e, &auth_contract);
         write_asset_unchecked(e, asset);
+        bump_instance_ttl(e);
     }
 
     pub fn admin(e: &Env) -> Address {
@@ -60,6 +73,8 @@ impl PrivacyChannelContract {
     }
 
     pub fn transact(e: Env, op: ChannelOperation) {
+        bump_instance_ttl(&e);
+
         let (utxo_op, total_deposit, total_withdraw) =
             pre_process_channel_operation(&e, op.clone());
 

--- a/contracts/privacy-channel/src/contract.rs
+++ b/contracts/privacy-channel/src/contract.rs
@@ -1,10 +1,18 @@
 use moonlight_errors::Error;
 use moonlight_utxo_core::core::UtxoHandlerTrait;
 use soroban_sdk::{
-    contract, contractimpl, panic_with_error, symbol_short, Address, BytesN, Env, Symbol, Vec,
+    contract, contractevent, contractimpl, panic_with_error, symbol_short, Address, BytesN, Env,
+    Symbol, Vec,
 };
 use stellar_access::ownable;
 use stellar_contract_utils::upgradeable;
+
+// MOON-09: dedicated upgrade event for the governance audit trail.
+#[contractevent(data_format = "single-value")]
+pub struct Upgraded {
+    #[topic]
+    pub wasm_hash: BytesN<32>,
+}
 
 use crate::{
     storage::{read_asset, read_supply, write_asset_unchecked},
@@ -69,6 +77,10 @@ impl PrivacyChannelContract {
 
     pub fn upgrade(e: &Env, wasm_hash: BytesN<32>) {
         ownable::enforce_owner_auth(e);
+        Upgraded {
+            wasm_hash: wasm_hash.clone(),
+        }
+        .publish(e);
         upgradeable::upgrade(e, &wasm_hash);
     }
 

--- a/contracts/privacy-channel/src/test/mod.rs
+++ b/contracts/privacy-channel/src/test/mod.rs
@@ -2,4 +2,6 @@ pub mod channel_operation_builder;
 #[cfg(test)]
 pub mod moon01;
 #[cfg(test)]
+pub mod moon05;
+#[cfg(test)]
 pub mod test;

--- a/contracts/privacy-channel/src/test/mod.rs
+++ b/contracts/privacy-channel/src/test/mod.rs
@@ -1,3 +1,5 @@
 pub mod channel_operation_builder;
 #[cfg(test)]
+pub mod moon01;
+#[cfg(test)]
 pub mod test;

--- a/contracts/privacy-channel/src/test/mod.rs
+++ b/contracts/privacy-channel/src/test/mod.rs
@@ -4,4 +4,6 @@ pub mod moon01;
 #[cfg(test)]
 pub mod moon05;
 #[cfg(test)]
+pub mod moon06;
+#[cfg(test)]
 pub mod test;

--- a/contracts/privacy-channel/src/test/moon01.rs
+++ b/contracts/privacy-channel/src/test/moon01.rs
@@ -1,0 +1,326 @@
+#![cfg(test)]
+//! MOON-01 regression tests: executed create/withdraw effects must be exactly the set of
+//! owner-signed `Create` / `ExtWithdraw` conditions. The headline test reproduces the audit's
+//! redirect attack and proves the contract now REJECTS it; the others prove legitimate bundles
+//! (multi-spend full-output-set, multi-spend partition, and the withdraw flow) are still ACCEPTED.
+extern crate std;
+
+use crate::{
+    contract::PrivacyChannelContractClient,
+    test::{channel_operation_builder::ChannelOperationBuilder, test::create_contracts},
+};
+use channel_auth_contract::contract::ChannelAuthContractClient;
+use moonlight_errors::Error as ContractError;
+use moonlight_helpers::testutils::{
+    keys::{Ed25519Account, P256KeyPair},
+    snapshot::{get_env_with_g_accounts, get_snapshot_g_accounts},
+};
+use moonlight_primitives::Condition;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    vec, Address, BytesN, Env, Error, Vec,
+};
+use token_contract::TestTokenClient as TokenClient;
+
+/// Fund one or more UTXOs by performing a real (provider- + depositor-signed) deposit whose
+/// conditions authorize exactly the given creates. Mirrors `local-dev/lib/client/deposit.ts`.
+fn fund_utxos(
+    e: &Env,
+    channel: &PrivacyChannelContractClient,
+    auth: &ChannelAuthContractClient,
+    token: &TokenClient,
+    provider: &Ed25519Account,
+    depositor: &Ed25519Account,
+    creates: &Vec<(BytesN<65>, i128)>,
+    total: i128,
+    nonce: i64,
+) {
+    token.mock_all_auths().mint(&depositor.address, &total);
+
+    let mut conditions: Vec<Condition> = vec![e];
+    for (utxo, amount) in creates.iter() {
+        conditions.push_back(Condition::Create(utxo.clone(), amount));
+    }
+
+    let mut op = ChannelOperationBuilder::generate(
+        e,
+        channel.address.clone(),
+        auth.address.clone(),
+        token.address.clone(),
+    );
+    op.add_deposit(e, depositor.address.clone(), total, conditions);
+    for (utxo, amount) in creates.iter() {
+        op.add_create(utxo.clone(), amount);
+    }
+
+    let live = e.ledger().sequence() + 100;
+
+    let provider_sig = provider.sign(
+        e,
+        op.get_auth_entry_payload_hash_for_bundle(e, nonce, live),
+    );
+    op.add_provider_signature(e, provider.address.clone(), provider_sig, live);
+
+    let depositor_sig = depositor.sign_for_transaction(
+        e,
+        op.get_auth_entry_payload_hash_for_deposit(e, depositor.address.clone(), nonce, live),
+    );
+    op.add_deposit_signature(depositor.address.clone(), depositor_sig);
+
+    channel
+        .set_auths(&[
+            op.get_auth_entry(e, nonce, live),
+            op.get_auth_entry_for_deposit(e, depositor.address.clone(), nonce, live),
+        ])
+        .transact(&op.get_operation_bundle());
+}
+
+fn unauthorized(res_err: Option<Result<Error, soroban_sdk::InvokeError>>) {
+    assert_eq!(
+        res_err,
+        Some(Ok(Error::from_contract_error(
+            ContractError::UnauthorizedOperation as u32
+        )))
+    );
+}
+
+/// THE GATE (audit repro). A victim signs a spend authorizing an internal change-create, but the
+/// provider keeps `op.spend` byte-identical (so the P256 sig still verifies) and substitutes the
+/// output with a withdrawal to an attacker — perfectly balanced. Pre-fix this was ACCEPTED and the
+/// funds left the channel; post-fix it is REJECTED with `UnauthorizedOperation`.
+#[test]
+fn test_moon01_redirect_spend_output_to_attacker_withdraw_is_rejected() {
+    let e = get_env_with_g_accounts();
+    let (provider_a, _b, john, _jane, _) = get_snapshot_g_accounts(&e);
+    let (channel, auth, token, _admin) = create_contracts(&e);
+    auth.mock_all_auths().add_provider(&provider_a.address);
+
+    // Fund the victim UTXO with 500.
+    let utxo_victim = P256KeyPair::generate(&e);
+    let creates = vec![&e, (utxo_victim.public_key.clone(), 500_i128)];
+    fund_utxos(&e, &channel, &auth, &token, &provider_a, &john, &creates, 500, 0);
+    assert_eq!(channel.utxo_balance(&utxo_victim.public_key), 500);
+    assert_eq!(channel.supply(), 500);
+
+    e.ledger().set_sequence_number(3);
+    let live = e.ledger().sequence() + 100;
+    let nonce = 1;
+
+    let attacker = Address::generate(&e);
+    let utxo_change = P256KeyPair::generate(&e); // the create the victim THINKS they authorize
+
+    let mut atk = ChannelOperationBuilder::generate(
+        &e,
+        channel.address.clone(),
+        auth.address.clone(),
+        token.address.clone(),
+    );
+
+    // Victim authorizes an INTERNAL change-create of 500 to utxo_change...
+    atk.add_spend(
+        utxo_victim.public_key.clone(),
+        vec![&e, Condition::Create(utxo_change.public_key.clone(), 500_i128)],
+    );
+    // ...but the bundle drops the create and redirects 500 OUT to the attacker. Balanced (500==500).
+    atk.add_withdraw(&e, attacker.clone(), 500_i128, vec![&e]);
+
+    let p_sig = provider_a.sign(
+        &e,
+        atk.get_auth_entry_payload_hash_for_bundle(&e, nonce, live),
+    );
+    atk.add_provider_signature(&e, provider_a.address.clone(), p_sig, live);
+
+    // The victim's P256 signature is over the UNCHANGED conditions and still verifies.
+    let v_sig = utxo_victim.sign(&atk.get_auth_hash_for_spend(
+        &e,
+        utxo_victim.public_key.clone(),
+        live,
+    ));
+    atk.add_spend_signature(&e, utxo_victim.public_key.clone(), v_sig, live);
+
+    let res = channel
+        .set_auths(&[atk.get_auth_entry(&e, nonce, live)])
+        .try_transact(&atk.get_operation_bundle());
+
+    // POST-FIX: rejected, and no funds moved.
+    unauthorized(res.err());
+    assert_eq!(channel.utxo_balance(&utxo_victim.public_key), 500); // victim UTXO still unspent
+    assert_eq!(token.balance(&attacker), 0); // attacker received nothing
+    assert_eq!(channel.supply(), 500);
+}
+
+/// Sibling of the above: redirect the spend output to an attacker-owned CREATE (instead of a
+/// withdrawal). Also rejected — the executed create is not an authorized condition.
+#[test]
+fn test_moon01_redirect_spend_output_to_attacker_create_is_rejected() {
+    let e = get_env_with_g_accounts();
+    let (provider_a, _b, john, _jane, _) = get_snapshot_g_accounts(&e);
+    let (channel, auth, token, _admin) = create_contracts(&e);
+    auth.mock_all_auths().add_provider(&provider_a.address);
+
+    let utxo_victim = P256KeyPair::generate(&e);
+    let creates = vec![&e, (utxo_victim.public_key.clone(), 500_i128)];
+    fund_utxos(&e, &channel, &auth, &token, &provider_a, &john, &creates, 500, 0);
+
+    e.ledger().set_sequence_number(3);
+    let live = e.ledger().sequence() + 100;
+    let nonce = 1;
+
+    let utxo_intended = P256KeyPair::generate(&e);
+    let utxo_attacker = P256KeyPair::generate(&e);
+
+    let mut atk = ChannelOperationBuilder::generate(
+        &e,
+        channel.address.clone(),
+        auth.address.clone(),
+        token.address.clone(),
+    );
+    atk.add_spend(
+        utxo_victim.public_key.clone(),
+        vec![&e, Condition::Create(utxo_intended.public_key.clone(), 500_i128)],
+    );
+    // Substitute the create to an attacker-owned UTXO, same amount → balanced.
+    atk.add_create(utxo_attacker.public_key.clone(), 500_i128);
+
+    let p_sig = provider_a.sign(
+        &e,
+        atk.get_auth_entry_payload_hash_for_bundle(&e, nonce, live),
+    );
+    atk.add_provider_signature(&e, provider_a.address.clone(), p_sig, live);
+    let v_sig = utxo_victim.sign(&atk.get_auth_hash_for_spend(
+        &e,
+        utxo_victim.public_key.clone(),
+        live,
+    ));
+    atk.add_spend_signature(&e, utxo_victim.public_key.clone(), v_sig, live);
+
+    let res = channel
+        .set_auths(&[atk.get_auth_entry(&e, nonce, live)])
+        .try_transact(&atk.get_operation_bundle());
+
+    unauthorized(res.err());
+    assert_eq!(channel.utxo_balance(&utxo_victim.public_key), 500);
+    assert_eq!(channel.utxo_balance(&utxo_attacker.public_key), -1); // never created
+}
+
+/// Multi-spend legit bundle where EACH spend signs the FULL output set (the
+/// `local-dev/lib/client/send.ts` convention). Set/dedup comparison must accept it.
+#[test]
+fn test_moon01_multispend_full_outputset_is_accepted() {
+    let e = get_env_with_g_accounts();
+    let (provider_a, provider_b, john, _jane, _) = get_snapshot_g_accounts(&e);
+    let (channel, auth, token, _admin) = create_contracts(&e);
+    auth.mock_all_auths().add_provider(&provider_a.address);
+    auth.mock_all_auths().add_provider(&provider_b.address);
+
+    // Fund two victim UTXOs (300 + 200 = 500).
+    let utxo_a = P256KeyPair::generate(&e);
+    let utxo_b = P256KeyPair::generate(&e);
+    let creates = vec![
+        &e,
+        (utxo_a.public_key.clone(), 300_i128),
+        (utxo_b.public_key.clone(), 200_i128),
+    ];
+    fund_utxos(&e, &channel, &auth, &token, &provider_a, &john, &creates, 500, 0);
+
+    e.ledger().set_sequence_number(3);
+    let live = e.ledger().sequence() + 100;
+    let nonce = 1;
+
+    let utxo_x = P256KeyPair::generate(&e);
+    let utxo_y = P256KeyPair::generate(&e);
+    // Each spend carries the COMPLETE create set as its conditions.
+    let full: Vec<Condition> = vec![
+        &e,
+        Condition::Create(utxo_x.public_key.clone(), 200_i128),
+        Condition::Create(utxo_y.public_key.clone(), 300_i128),
+    ];
+
+    let mut op = ChannelOperationBuilder::generate(
+        &e,
+        channel.address.clone(),
+        auth.address.clone(),
+        token.address.clone(),
+    );
+    op.add_create(utxo_x.public_key.clone(), 200_i128);
+    op.add_create(utxo_y.public_key.clone(), 300_i128);
+    op.add_spend(utxo_a.public_key.clone(), full.clone());
+    op.add_spend(utxo_b.public_key.clone(), full.clone());
+
+    let p_sig = provider_b.sign(
+        &e,
+        op.get_auth_entry_payload_hash_for_bundle(&e, nonce, live),
+    );
+    op.add_provider_signature(&e, provider_b.address.clone(), p_sig, live);
+    for kp in [&utxo_a, &utxo_b] {
+        let sig = kp.sign(&op.get_auth_hash_for_spend(&e, kp.public_key.clone(), live));
+        op.add_spend_signature(&e, kp.public_key.clone(), sig, live);
+    }
+
+    channel
+        .set_auths(&[op.get_auth_entry(&e, nonce, live)])
+        .transact(&op.get_operation_bundle());
+
+    assert_eq!(channel.utxo_balance(&utxo_a.public_key), 0);
+    assert_eq!(channel.utxo_balance(&utxo_b.public_key), 0);
+    assert_eq!(channel.utxo_balance(&utxo_x.public_key), 200);
+    assert_eq!(channel.utxo_balance(&utxo_y.public_key), 300);
+    assert_eq!(channel.supply(), 500); // internal-only: supply unchanged
+}
+
+/// Legit withdraw flow (the `local-dev/lib/client/withdraw.ts` convention): the spend signs an
+/// `ExtWithdraw` + a change `Create`; both execute. Must be ACCEPTED, and funds reach the
+/// intended destination.
+#[test]
+fn test_moon01_legit_withdraw_is_accepted() {
+    let e = get_env_with_g_accounts();
+    let (provider_a, _b, john, _jane, _) = get_snapshot_g_accounts(&e);
+    let (channel, auth, token, _admin) = create_contracts(&e);
+    auth.mock_all_auths().add_provider(&provider_a.address);
+
+    let utxo_a = P256KeyPair::generate(&e);
+    let creates = vec![&e, (utxo_a.public_key.clone(), 500_i128)];
+    fund_utxos(&e, &channel, &auth, &token, &provider_a, &john, &creates, 500, 0);
+
+    e.ledger().set_sequence_number(3);
+    let live = e.ledger().sequence() + 100;
+    let nonce = 1;
+
+    let destination = Address::generate(&e);
+    let utxo_change = P256KeyPair::generate(&e);
+
+    let mut op = ChannelOperationBuilder::generate(
+        &e,
+        channel.address.clone(),
+        auth.address.clone(),
+        token.address.clone(),
+    );
+    // Spend authorizes: withdraw 400 to `destination` + keep 100 as change.
+    op.add_spend(
+        utxo_a.public_key.clone(),
+        vec![
+            &e,
+            Condition::ExtWithdraw(destination.clone(), 400_i128),
+            Condition::Create(utxo_change.public_key.clone(), 100_i128),
+        ],
+    );
+    op.add_create(utxo_change.public_key.clone(), 100_i128);
+    op.add_withdraw(&e, destination.clone(), 400_i128, vec![&e]);
+
+    let p_sig = provider_a.sign(
+        &e,
+        op.get_auth_entry_payload_hash_for_bundle(&e, nonce, live),
+    );
+    op.add_provider_signature(&e, provider_a.address.clone(), p_sig, live);
+    let v_sig = utxo_a.sign(&op.get_auth_hash_for_spend(&e, utxo_a.public_key.clone(), live));
+    op.add_spend_signature(&e, utxo_a.public_key.clone(), v_sig, live);
+
+    channel
+        .set_auths(&[op.get_auth_entry(&e, nonce, live)])
+        .transact(&op.get_operation_bundle());
+
+    assert_eq!(token.balance(&destination), 400); // funds reached the intended recipient
+    assert_eq!(channel.utxo_balance(&utxo_change.public_key), 100);
+    assert_eq!(channel.utxo_balance(&utxo_a.public_key), 0);
+    assert_eq!(channel.supply(), 100); // 500 deposited - 400 withdrawn
+}

--- a/contracts/privacy-channel/src/test/moon01.rs
+++ b/contracts/privacy-channel/src/test/moon01.rs
@@ -1,8 +1,11 @@
 #![cfg(test)]
-//! MOON-01 regression tests: executed create/withdraw effects must be exactly the set of
-//! owner-signed `Create` / `ExtWithdraw` conditions. The headline test reproduces the audit's
-//! redirect attack and proves the contract now REJECTS it; the others prove legitimate bundles
-//! (multi-spend full-output-set, multi-spend partition, and the withdraw flow) are still ACCEPTED.
+//! MOON-01 regression tests: every owner-signed `Create` / `ExtWithdraw` condition must be executed
+//! exactly (subset binding `authorized ⊆ executed`), so a signer's outputs can't be dropped,
+//! reduced, or redirected. Extra executed creates/withdraws (the provider fee) are allowed but
+//! bounded by the balance check to the residual the signers left. The headline tests reproduce the
+//! audit's redirect attack and prove it is now REJECTED; others prove legitimate bundles
+//! (multi-spend full-set, partition, withdraw, and provider-fee) are ACCEPTED, and that a provider
+//! cannot take more than the residual.
 extern crate std;
 
 use crate::{
@@ -55,10 +58,7 @@ fn fund_utxos(
 
     let live = e.ledger().sequence() + 100;
 
-    let provider_sig = provider.sign(
-        e,
-        op.get_auth_entry_payload_hash_for_bundle(e, nonce, live),
-    );
+    let provider_sig = provider.sign(e, op.get_auth_entry_payload_hash_for_bundle(e, nonce, live));
     op.add_provider_signature(e, provider.address.clone(), provider_sig, live);
 
     let depositor_sig = depositor.sign_for_transaction(
@@ -84,6 +84,15 @@ fn unauthorized(res_err: Option<Result<Error, soroban_sdk::InvokeError>>) {
     );
 }
 
+fn unbalanced(res_err: Option<Result<Error, soroban_sdk::InvokeError>>) {
+    assert_eq!(
+        res_err,
+        Some(Ok(Error::from_contract_error(
+            ContractError::UnbalancedBundle as u32
+        )))
+    );
+}
+
 /// THE GATE (audit repro). A victim signs a spend authorizing an internal change-create, but the
 /// provider keeps `op.spend` byte-identical (so the P256 sig still verifies) and substitutes the
 /// output with a withdrawal to an attacker — perfectly balanced. Pre-fix this was ACCEPTED and the
@@ -98,7 +107,17 @@ fn test_moon01_redirect_spend_output_to_attacker_withdraw_is_rejected() {
     // Fund the victim UTXO with 500.
     let utxo_victim = P256KeyPair::generate(&e);
     let creates = vec![&e, (utxo_victim.public_key.clone(), 500_i128)];
-    fund_utxos(&e, &channel, &auth, &token, &provider_a, &john, &creates, 500, 0);
+    fund_utxos(
+        &e,
+        &channel,
+        &auth,
+        &token,
+        &provider_a,
+        &john,
+        &creates,
+        500,
+        0,
+    );
     assert_eq!(channel.utxo_balance(&utxo_victim.public_key), 500);
     assert_eq!(channel.supply(), 500);
 
@@ -119,7 +138,10 @@ fn test_moon01_redirect_spend_output_to_attacker_withdraw_is_rejected() {
     // Victim authorizes an INTERNAL change-create of 500 to utxo_change...
     atk.add_spend(
         utxo_victim.public_key.clone(),
-        vec![&e, Condition::Create(utxo_change.public_key.clone(), 500_i128)],
+        vec![
+            &e,
+            Condition::Create(utxo_change.public_key.clone(), 500_i128),
+        ],
     );
     // ...but the bundle drops the create and redirects 500 OUT to the attacker. Balanced (500==500).
     atk.add_withdraw(&e, attacker.clone(), 500_i128, vec![&e]);
@@ -131,11 +153,8 @@ fn test_moon01_redirect_spend_output_to_attacker_withdraw_is_rejected() {
     atk.add_provider_signature(&e, provider_a.address.clone(), p_sig, live);
 
     // The victim's P256 signature is over the UNCHANGED conditions and still verifies.
-    let v_sig = utxo_victim.sign(&atk.get_auth_hash_for_spend(
-        &e,
-        utxo_victim.public_key.clone(),
-        live,
-    ));
+    let v_sig =
+        utxo_victim.sign(&atk.get_auth_hash_for_spend(&e, utxo_victim.public_key.clone(), live));
     atk.add_spend_signature(&e, utxo_victim.public_key.clone(), v_sig, live);
 
     let res = channel
@@ -160,7 +179,17 @@ fn test_moon01_redirect_spend_output_to_attacker_create_is_rejected() {
 
     let utxo_victim = P256KeyPair::generate(&e);
     let creates = vec![&e, (utxo_victim.public_key.clone(), 500_i128)];
-    fund_utxos(&e, &channel, &auth, &token, &provider_a, &john, &creates, 500, 0);
+    fund_utxos(
+        &e,
+        &channel,
+        &auth,
+        &token,
+        &provider_a,
+        &john,
+        &creates,
+        500,
+        0,
+    );
 
     e.ledger().set_sequence_number(3);
     let live = e.ledger().sequence() + 100;
@@ -177,7 +206,10 @@ fn test_moon01_redirect_spend_output_to_attacker_create_is_rejected() {
     );
     atk.add_spend(
         utxo_victim.public_key.clone(),
-        vec![&e, Condition::Create(utxo_intended.public_key.clone(), 500_i128)],
+        vec![
+            &e,
+            Condition::Create(utxo_intended.public_key.clone(), 500_i128),
+        ],
     );
     // Substitute the create to an attacker-owned UTXO, same amount → balanced.
     atk.add_create(utxo_attacker.public_key.clone(), 500_i128);
@@ -187,11 +219,8 @@ fn test_moon01_redirect_spend_output_to_attacker_create_is_rejected() {
         atk.get_auth_entry_payload_hash_for_bundle(&e, nonce, live),
     );
     atk.add_provider_signature(&e, provider_a.address.clone(), p_sig, live);
-    let v_sig = utxo_victim.sign(&atk.get_auth_hash_for_spend(
-        &e,
-        utxo_victim.public_key.clone(),
-        live,
-    ));
+    let v_sig =
+        utxo_victim.sign(&atk.get_auth_hash_for_spend(&e, utxo_victim.public_key.clone(), live));
     atk.add_spend_signature(&e, utxo_victim.public_key.clone(), v_sig, live);
 
     let res = channel
@@ -221,7 +250,17 @@ fn test_moon01_multispend_full_outputset_is_accepted() {
         (utxo_a.public_key.clone(), 300_i128),
         (utxo_b.public_key.clone(), 200_i128),
     ];
-    fund_utxos(&e, &channel, &auth, &token, &provider_a, &john, &creates, 500, 0);
+    fund_utxos(
+        &e,
+        &channel,
+        &auth,
+        &token,
+        &provider_a,
+        &john,
+        &creates,
+        500,
+        0,
+    );
 
     e.ledger().set_sequence_number(3);
     let live = e.ledger().sequence() + 100;
@@ -280,7 +319,17 @@ fn test_moon01_legit_withdraw_is_accepted() {
 
     let utxo_a = P256KeyPair::generate(&e);
     let creates = vec![&e, (utxo_a.public_key.clone(), 500_i128)];
-    fund_utxos(&e, &channel, &auth, &token, &provider_a, &john, &creates, 500, 0);
+    fund_utxos(
+        &e,
+        &channel,
+        &auth,
+        &token,
+        &provider_a,
+        &john,
+        &creates,
+        500,
+        0,
+    );
 
     e.ledger().set_sequence_number(3);
     let live = e.ledger().sequence() + 100;
@@ -323,4 +372,191 @@ fn test_moon01_legit_withdraw_is_accepted() {
     assert_eq!(channel.utxo_balance(&utxo_change.public_key), 100);
     assert_eq!(channel.utxo_balance(&utxo_a.public_key), 0);
     assert_eq!(channel.supply(), 100); // 500 deposited - 400 withdrawn
+}
+
+/// Provider fee WITHIN the residual is accepted (the real e2e shape): user spends 1000 and signs
+/// `Create(dest, 995)`; the provider adds an unsigned `Create(opex, 5)` fee. Balanced 1000 == 1000.
+#[test]
+fn test_moon01_provider_fee_within_residual_is_accepted() {
+    let e = get_env_with_g_accounts();
+    let (provider_a, _b, john, _jane, _) = get_snapshot_g_accounts(&e);
+    let (channel, auth, token, _admin) = create_contracts(&e);
+    auth.mock_all_auths().add_provider(&provider_a.address);
+
+    let utxo_src = P256KeyPair::generate(&e);
+    let creates = vec![&e, (utxo_src.public_key.clone(), 1000_i128)];
+    fund_utxos(
+        &e,
+        &channel,
+        &auth,
+        &token,
+        &provider_a,
+        &john,
+        &creates,
+        1000,
+        0,
+    );
+
+    e.ledger().set_sequence_number(3);
+    let live = e.ledger().sequence() + 100;
+    let nonce = 1;
+
+    let utxo_dest = P256KeyPair::generate(&e);
+    let utxo_opex = P256KeyPair::generate(&e);
+
+    let mut op = ChannelOperationBuilder::generate(
+        &e,
+        channel.address.clone(),
+        auth.address.clone(),
+        token.address.clone(),
+    );
+    op.add_spend(
+        utxo_src.public_key.clone(),
+        vec![
+            &e,
+            Condition::Create(utxo_dest.public_key.clone(), 995_i128),
+        ], // signer claims 995
+    );
+    op.add_create(utxo_dest.public_key.clone(), 995_i128);
+    op.add_create(utxo_opex.public_key.clone(), 5_i128); // provider fee (unsigned), == residual
+
+    let p_sig = provider_a.sign(
+        &e,
+        op.get_auth_entry_payload_hash_for_bundle(&e, nonce, live),
+    );
+    op.add_provider_signature(&e, provider_a.address.clone(), p_sig, live);
+    let s_sig = utxo_src.sign(&op.get_auth_hash_for_spend(&e, utxo_src.public_key.clone(), live));
+    op.add_spend_signature(&e, utxo_src.public_key.clone(), s_sig, live);
+
+    channel
+        .set_auths(&[op.get_auth_entry(&e, nonce, live)])
+        .transact(&op.get_operation_bundle());
+
+    assert_eq!(channel.utxo_balance(&utxo_src.public_key), 0);
+    assert_eq!(channel.utxo_balance(&utxo_dest.public_key), 995); // signer's output delivered exactly
+    assert_eq!(channel.utxo_balance(&utxo_opex.public_key), 5); // provider fee
+}
+
+/// Provider tries to take MORE than the residual: user signs `Create(dest, 995)`, provider adds
+/// `Create(opex, 50)` (residual is only 5). Balance check rejects (Σcreated 1045 != Σspent 1000).
+#[test]
+fn test_moon01_provider_fee_exceeding_residual_is_rejected() {
+    let e = get_env_with_g_accounts();
+    let (provider_a, _b, john, _jane, _) = get_snapshot_g_accounts(&e);
+    let (channel, auth, token, _admin) = create_contracts(&e);
+    auth.mock_all_auths().add_provider(&provider_a.address);
+
+    let utxo_src = P256KeyPair::generate(&e);
+    let creates = vec![&e, (utxo_src.public_key.clone(), 1000_i128)];
+    fund_utxos(
+        &e,
+        &channel,
+        &auth,
+        &token,
+        &provider_a,
+        &john,
+        &creates,
+        1000,
+        0,
+    );
+
+    e.ledger().set_sequence_number(3);
+    let live = e.ledger().sequence() + 100;
+    let nonce = 1;
+
+    let utxo_dest = P256KeyPair::generate(&e);
+    let utxo_opex = P256KeyPair::generate(&e);
+
+    let mut op = ChannelOperationBuilder::generate(
+        &e,
+        channel.address.clone(),
+        auth.address.clone(),
+        token.address.clone(),
+    );
+    op.add_spend(
+        utxo_src.public_key.clone(),
+        vec![
+            &e,
+            Condition::Create(utxo_dest.public_key.clone(), 995_i128),
+        ],
+    );
+    op.add_create(utxo_dest.public_key.clone(), 995_i128);
+    op.add_create(utxo_opex.public_key.clone(), 50_i128); // exceeds the 5 residual
+
+    let p_sig = provider_a.sign(
+        &e,
+        op.get_auth_entry_payload_hash_for_bundle(&e, nonce, live),
+    );
+    op.add_provider_signature(&e, provider_a.address.clone(), p_sig, live);
+    let s_sig = utxo_src.sign(&op.get_auth_hash_for_spend(&e, utxo_src.public_key.clone(), live));
+    op.add_spend_signature(&e, utxo_src.public_key.clone(), s_sig, live);
+
+    let res = channel
+        .set_auths(&[op.get_auth_entry(&e, nonce, live)])
+        .try_transact(&op.get_operation_bundle());
+
+    unbalanced(res.err());
+    assert_eq!(channel.utxo_balance(&utxo_src.public_key), 1000); // nothing moved
+}
+
+/// Pure internal transfer (residual 0): user spends 500 and signs `Create(dest, 500)`. A provider
+/// attempt to add ANY extra create has no residual to fund it -> balance check rejects.
+#[test]
+fn test_moon01_internal_transfer_extra_create_is_rejected() {
+    let e = get_env_with_g_accounts();
+    let (provider_a, _b, john, _jane, _) = get_snapshot_g_accounts(&e);
+    let (channel, auth, token, _admin) = create_contracts(&e);
+    auth.mock_all_auths().add_provider(&provider_a.address);
+
+    let utxo_src = P256KeyPair::generate(&e);
+    let creates = vec![&e, (utxo_src.public_key.clone(), 500_i128)];
+    fund_utxos(
+        &e,
+        &channel,
+        &auth,
+        &token,
+        &provider_a,
+        &john,
+        &creates,
+        500,
+        0,
+    );
+
+    e.ledger().set_sequence_number(3);
+    let live = e.ledger().sequence() + 100;
+    let nonce = 1;
+
+    let utxo_dest = P256KeyPair::generate(&e);
+    let utxo_opex = P256KeyPair::generate(&e);
+
+    let mut op = ChannelOperationBuilder::generate(
+        &e,
+        channel.address.clone(),
+        auth.address.clone(),
+        token.address.clone(),
+    );
+    op.add_spend(
+        utxo_src.public_key.clone(),
+        vec![
+            &e,
+            Condition::Create(utxo_dest.public_key.clone(), 500_i128),
+        ], // claims all 500
+    );
+    op.add_create(utxo_dest.public_key.clone(), 500_i128);
+    op.add_create(utxo_opex.public_key.clone(), 1_i128); // no residual to fund this
+
+    let p_sig = provider_a.sign(
+        &e,
+        op.get_auth_entry_payload_hash_for_bundle(&e, nonce, live),
+    );
+    op.add_provider_signature(&e, provider_a.address.clone(), p_sig, live);
+    let s_sig = utxo_src.sign(&op.get_auth_hash_for_spend(&e, utxo_src.public_key.clone(), live));
+    op.add_spend_signature(&e, utxo_src.public_key.clone(), s_sig, live);
+
+    let res = channel
+        .set_auths(&[op.get_auth_entry(&e, nonce, live)])
+        .try_transact(&op.get_operation_bundle());
+
+    unbalanced(res.err());
+    assert_eq!(channel.utxo_balance(&utxo_src.public_key), 500);
 }

--- a/contracts/privacy-channel/src/test/moon05.rs
+++ b/contracts/privacy-channel/src/test/moon05.rs
@@ -1,0 +1,50 @@
+#![cfg(test)]
+//! MOON-05: deposit/withdraw amounts must be strictly positive (checked in-contract, before any
+//! signature verification, rather than relying on the asset SAC to reject them).
+extern crate std;
+
+use crate::{test::test::create_contracts, transact::ChannelOperation};
+use moonlight_errors::Error as ContractError;
+use moonlight_helpers::testutils::snapshot::get_env_with_g_accounts;
+use soroban_sdk::{testutils::Address as _, vec, Address, Error};
+
+fn assert_invalid_amount(res_err: Option<Result<Error, soroban_sdk::InvokeError>>) {
+    assert_eq!(
+        res_err,
+        Some(Ok(Error::from_contract_error(
+            ContractError::InvalidExternalAmount as u32
+        )))
+    );
+}
+
+#[test]
+fn test_moon05_zero_withdraw_amount_is_rejected() {
+    let e = get_env_with_g_accounts();
+    let (channel, _auth, _token, _admin) = create_contracts(&e);
+    let to = Address::generate(&e);
+
+    let op = ChannelOperation {
+        spend: vec![&e],
+        create: vec![&e],
+        deposit: vec![&e],
+        withdraw: vec![&e, (to, 0_i128, vec![&e])],
+    };
+
+    assert_invalid_amount(channel.try_transact(&op).err());
+}
+
+#[test]
+fn test_moon05_negative_deposit_amount_is_rejected() {
+    let e = get_env_with_g_accounts();
+    let (channel, _auth, _token, _admin) = create_contracts(&e);
+    let from = Address::generate(&e);
+
+    let op = ChannelOperation {
+        spend: vec![&e],
+        create: vec![&e],
+        deposit: vec![&e, (from, -1_i128, vec![&e])],
+        withdraw: vec![&e],
+    };
+
+    assert_invalid_amount(channel.try_transact(&op).err());
+}

--- a/contracts/privacy-channel/src/test/moon06.rs
+++ b/contracts/privacy-channel/src/test/moon06.rs
@@ -1,0 +1,86 @@
+#![cfg(test)]
+//! MOON-06: a malicious/non-standard asset SAC must not be able to re-enter `transact` via the
+//! deposit/withdraw transfer callback. The reentrancy guard rejects the nested call.
+extern crate std;
+
+use crate::{
+    contract::{PrivacyChannelContract, PrivacyChannelContractArgs, PrivacyChannelContractClient},
+    transact::ChannelOperation,
+};
+use channel_auth_contract::contract::{ChannelAuthContract, ChannelAuthContractArgs};
+use moonlight_helpers::testutils::{keys::P256KeyPair, snapshot::get_env_with_g_accounts};
+use moonlight_primitives::Condition;
+use soroban_sdk::{
+    contract, contractimpl, symbol_short, testutils::Address as _, vec, Address, Env, MuxedAddress,
+};
+
+/// A malicious "asset" whose `transfer` re-enters the channel's `transact`.
+#[contract]
+struct ReentrantAsset;
+
+#[contractimpl]
+impl ReentrantAsset {
+    pub fn set_channel(e: Env, channel: Address) {
+        e.storage().instance().set(&symbol_short!("CH"), &channel);
+    }
+
+    // Mirrors the SEP-41 token `transfer` signature so the channel's `TokenClient` resolves to it.
+    pub fn transfer(e: Env, _from: Address, _to: MuxedAddress, _amount: i128) {
+        let channel: Address = e.storage().instance().get(&symbol_short!("CH")).unwrap();
+        let empty = ChannelOperation {
+            spend: vec![&e],
+            create: vec![&e],
+            deposit: vec![&e],
+            withdraw: vec![&e],
+        };
+        PrivacyChannelContractClient::new(&e, &channel).transact(&empty);
+    }
+}
+
+#[test]
+fn test_moon06_reentrant_asset_call_is_rejected() {
+    let e = get_env_with_g_accounts();
+    e.mock_all_auths();
+
+    let admin = Address::generate(&e);
+    let auth_id = e.register(
+        ChannelAuthContract,
+        ChannelAuthContractArgs::__constructor(&admin),
+    );
+    let asset_id = e.register(ReentrantAsset, ());
+    let channel_id = e.register(
+        PrivacyChannelContract,
+        PrivacyChannelContractArgs::__constructor(&admin, &auth_id, &asset_id),
+    );
+    let channel = PrivacyChannelContractClient::new(&e, &channel_id);
+
+    ReentrantAssetClient::new(&e, &asset_id).set_channel(&channel_id);
+
+    // A deposit triggers asset.transfer(...), which re-enters channel.transact.
+    let depositor = Address::generate(&e);
+    let utxo = P256KeyPair::generate(&e);
+    let op = ChannelOperation {
+        spend: vec![&e],
+        create: vec![&e, (utxo.public_key.clone(), 100_i128)],
+        deposit: vec![
+            &e,
+            (
+                depositor,
+                100_i128,
+                vec![&e, Condition::Create(utxo.public_key.clone(), 100_i128)],
+            ),
+        ],
+        withdraw: vec![&e],
+    };
+
+    let res = channel.try_transact(&op);
+
+    // The re-entrant call trips the guard; the whole transaction reverts. (The inner ReentrantCall
+    // surfaces through the asset/auth boundary as the host's Context/InvalidAction wrap, as the
+    // codebase documents for cross-boundary contract errors.) Without the guard the inner empty
+    // transact would be a no-op and the deposit would COMPLETE — so the revert + unchanged state
+    // below is attributable to the guard.
+    assert!(res.is_err());
+    assert_eq!(channel.supply(), 0); // deposit did not go through
+    assert_eq!(channel.utxo_balance(&utxo.public_key), -1); // UTXO not created
+}

--- a/contracts/privacy-channel/src/transact.rs
+++ b/contracts/privacy-channel/src/transact.rs
@@ -7,8 +7,7 @@ use moonlight_utxo_core::core::{calculate_auth_requirements, InternalBundle};
 use soroban_sdk::{
     assert_with_error,
     auth::{ContractContext, InvokerContractAuthEntry, SubContractInvocation},
-    contracttype,
-    panic_with_error,
+    contracttype, panic_with_error,
     token::TokenClient,
     vec,
     xdr::ToXdr,
@@ -60,13 +59,14 @@ pub fn pre_process_channel_operation(
 
     verify_external_operations(&e, op.deposit.clone(), op.withdraw.clone());
 
-    // MOON-01: bind executed effects to owner-signed conditions. The balance check in
+    // MOON-01: bind owner-signed conditions to executed effects. The balance check in
     // `process_bundle` only guarantees value conservation, not *where* the value goes; without
     // this, a provider can keep `op.spend` byte-identical (owner P256 sig still verifies) and
     // redirect `op.create` / `op.withdraw` to an attacker while staying balanced. This enforces
-    // that the set of executed create/withdraw effects EXACTLY equals the set of Create/ExtWithdraw
-    // conditions signed by the spend owners (P256) and depositors (Ed25519).
-    assert_executed_effects_are_authorized(&e, &op);
+    // that every Create/ExtWithdraw condition signed by a spend owner (P256) or depositor (Ed25519)
+    // is executed exactly (same utxo/addr + amount). Extra executed creates/withdraws are allowed
+    // (the provider fee); the balance check bounds them to the residual the signers left.
+    assert_signed_effects_are_executed(&e, &op);
 
     let auth_req = calculate_auth_requirements(e, &op.spend); // &vec![&e]);
 
@@ -85,8 +85,8 @@ pub fn pre_process_channel_operation(
     return (utxo_op, total_deposit, total_withdraw);
 }
 
-/// MOON-01 binding: enforce that the bundle's executed create/withdraw effects are exactly the
-/// set of `Create` / `ExtWithdraw` conditions that were cryptographically authorized.
+/// MOON-01 binding: enforce that every cryptographically-signed `Create` / `ExtWithdraw` condition
+/// is executed exactly by the bundle (subset direction `authorized ⊆ executed`).
 ///
 /// Authorized set = every `Condition::Create` / `Condition::ExtWithdraw` found in the spend
 /// conditions (P256-signed by the UTXO owner, verified via the auth contract) and the deposit
@@ -98,14 +98,19 @@ pub fn pre_process_channel_operation(
 /// Executed set = `op.create` rendered as `Condition::Create` and `op.withdraw` rendered as
 /// `Condition::ExtWithdraw`.
 ///
-/// Both sets are compared by canonical XDR bytes with set (dedup) semantics, so a multi-spend
-/// bundle where each spend repeats (or partitions) the full output set is accepted as long as the
-/// union matches the executed effects.
+/// Compared by canonical XDR bytes with set (dedup) semantics, so a multi-spend bundle where each
+/// spend repeats (or partitions) the output set is accepted as long as every signed effect appears
+/// in the executed effects. A signer's outputs therefore cannot be dropped, reduced, amount-changed,
+/// or redirected (any of those removes the exact `(utxo|addr, amount)` key from `executed`).
+///
+/// EXTRA executed creates/withdraws beyond the signed set are permitted — this is the provider fee.
+/// The retained balance check (`Σexecuted == Σinputs`) bounds those extras to exactly the residual
+/// the signers left unallocated (deposit over-funded / spend under-claimed); for a pure internal
+/// transfer the residual is zero, so no extra create can balance.
 ///
 /// ### Panics
-/// - `UnauthorizedOperation` if an executed effect is not authorized, or an authorized
-///   create/withdraw condition is not executed.
-fn assert_executed_effects_are_authorized(e: &Env, op: &ChannelOperation) {
+/// - `UnauthorizedOperation` if a signed create/withdraw condition is not executed.
+fn assert_signed_effects_are_executed(e: &Env, op: &ChannelOperation) {
     let mut authorized: Map<Bytes, ()> = Map::new(e);
     collect_authorized_effects(e, &mut authorized, &op.spend);
     collect_authorized_effects_from_external(e, &mut authorized, &op.deposit);
@@ -118,14 +123,9 @@ fn assert_executed_effects_are_authorized(e: &Env, op: &ChannelOperation) {
         executed.set(Condition::ExtWithdraw(addr, amount).to_xdr(e), ());
     }
 
-    // Exact set-equality: |executed| == |authorized| and executed ⊆ authorized ⇒ sets equal.
-    assert_with_error!(
-        e,
-        executed.len() == authorized.len(),
-        Error::UnauthorizedOperation
-    );
-    for key in executed.keys().iter() {
-        assert_with_error!(e, authorized.contains_key(key), Error::UnauthorizedOperation);
+    // Subset: every signed effect must be executed exactly. Extra executed effects are allowed.
+    for key in authorized.keys().iter() {
+        assert_with_error!(e, executed.contains_key(key), Error::UnauthorizedOperation);
     }
 }
 

--- a/contracts/privacy-channel/src/transact.rs
+++ b/contracts/privacy-channel/src/transact.rs
@@ -41,6 +41,8 @@ pub fn pre_process_channel_operation(
 
     let mut total_deposit: i128 = 0;
     for (_addr, amt, _conds) in op.deposit.iter() {
+        // MOON-05: reject non-positive amounts in-contract rather than relying on the asset SAC.
+        assert_with_error!(&e, amt > 0, Error::InvalidExternalAmount);
         total_deposit = match total_deposit.checked_add(amt) {
             Some(v) => v,
             None => panic_with_error!(&e, Error::AmountOverflow),
@@ -49,6 +51,7 @@ pub fn pre_process_channel_operation(
 
     let mut total_withdraw: i128 = 0;
     for (_addr, amt, _conds) in op.withdraw.iter() {
+        assert_with_error!(&e, amt > 0, Error::InvalidExternalAmount);
         total_withdraw = match total_withdraw.checked_add(amt) {
             Some(v) => v,
             None => panic_with_error!(&e, Error::AmountOverflow),

--- a/contracts/privacy-channel/src/transact.rs
+++ b/contracts/privacy-channel/src/transact.rs
@@ -7,9 +7,12 @@ use moonlight_utxo_core::core::{calculate_auth_requirements, InternalBundle};
 use soroban_sdk::{
     assert_with_error,
     auth::{ContractContext, InvokerContractAuthEntry, SubContractInvocation},
-    contracttype, panic_with_error,
+    contracttype,
+    panic_with_error,
     token::TokenClient,
-    vec, Address, BytesN, Env, IntoVal, Symbol, Val, Vec,
+    vec,
+    xdr::ToXdr,
+    Address, Bytes, BytesN, Env, IntoVal, Map, Symbol, Val, Vec,
 };
 
 use crate::{
@@ -54,6 +57,14 @@ pub fn pre_process_channel_operation(
 
     verify_external_operations(&e, op.deposit.clone(), op.withdraw.clone());
 
+    // MOON-01: bind executed effects to owner-signed conditions. The balance check in
+    // `process_bundle` only guarantees value conservation, not *where* the value goes; without
+    // this, a provider can keep `op.spend` byte-identical (owner P256 sig still verifies) and
+    // redirect `op.create` / `op.withdraw` to an attacker while staying balanced. This enforces
+    // that the set of executed create/withdraw effects EXACTLY equals the set of Create/ExtWithdraw
+    // conditions signed by the spend owners (P256) and depositors (Ed25519).
+    assert_executed_effects_are_authorized(&e, &op);
+
     let auth_req = calculate_auth_requirements(e, &op.spend); // &vec![&e]);
 
     //get the spend array without conditions
@@ -69,6 +80,84 @@ pub fn pre_process_channel_operation(
     };
 
     return (utxo_op, total_deposit, total_withdraw);
+}
+
+/// MOON-01 binding: enforce that the bundle's executed create/withdraw effects are exactly the
+/// set of `Create` / `ExtWithdraw` conditions that were cryptographically authorized.
+///
+/// Authorized set = every `Condition::Create` / `Condition::ExtWithdraw` found in the spend
+/// conditions (P256-signed by the UTXO owner, verified via the auth contract) and the deposit
+/// conditions (Ed25519-signed by the depositor via `require_auth_for_args`). Withdraw-tuple
+/// conditions are unsigned and are intentionally NOT a source of authorization. `ExtDeposit`
+/// (already bound by the depositor's SAC-transfer auth) and `ExtIntegration` (never executed) are
+/// not execution-bound and are ignored.
+///
+/// Executed set = `op.create` rendered as `Condition::Create` and `op.withdraw` rendered as
+/// `Condition::ExtWithdraw`.
+///
+/// Both sets are compared by canonical XDR bytes with set (dedup) semantics, so a multi-spend
+/// bundle where each spend repeats (or partitions) the full output set is accepted as long as the
+/// union matches the executed effects.
+///
+/// ### Panics
+/// - `UnauthorizedOperation` if an executed effect is not authorized, or an authorized
+///   create/withdraw condition is not executed.
+fn assert_executed_effects_are_authorized(e: &Env, op: &ChannelOperation) {
+    let mut authorized: Map<Bytes, ()> = Map::new(e);
+    collect_authorized_effects(e, &mut authorized, &op.spend);
+    collect_authorized_effects_from_external(e, &mut authorized, &op.deposit);
+
+    let mut executed: Map<Bytes, ()> = Map::new(e);
+    for (utxo, amount) in op.create.iter() {
+        executed.set(Condition::Create(utxo, amount).to_xdr(e), ());
+    }
+    for (addr, amount, _conds) in op.withdraw.iter() {
+        executed.set(Condition::ExtWithdraw(addr, amount).to_xdr(e), ());
+    }
+
+    // Exact set-equality: |executed| == |authorized| and executed ⊆ authorized ⇒ sets equal.
+    assert_with_error!(
+        e,
+        executed.len() == authorized.len(),
+        Error::UnauthorizedOperation
+    );
+    for key in executed.keys().iter() {
+        assert_with_error!(e, authorized.contains_key(key), Error::UnauthorizedOperation);
+    }
+}
+
+fn collect_authorized_effects(
+    e: &Env,
+    set: &mut Map<Bytes, ()>,
+    spend: &Vec<(BytesN<65>, Vec<Condition>)>,
+) {
+    for (_utxo, conditions) in spend.iter() {
+        for cond in conditions.iter() {
+            if is_execution_bound(&cond) {
+                set.set(cond.to_xdr(e), ());
+            }
+        }
+    }
+}
+
+fn collect_authorized_effects_from_external(
+    e: &Env,
+    set: &mut Map<Bytes, ()>,
+    external: &Vec<(Address, i128, Vec<Condition>)>,
+) {
+    for (_addr, _amount, conditions) in external.iter() {
+        for cond in conditions.iter() {
+            if is_execution_bound(&cond) {
+                set.set(cond.to_xdr(e), ());
+            }
+        }
+    }
+}
+
+/// Only `Create` and `ExtWithdraw` conditions describe on-ledger value movement the bundle
+/// executes; they are the effects this binding governs.
+fn is_execution_bound(cond: &Condition) -> bool {
+    matches!(cond, Condition::Create(..) | Condition::ExtWithdraw(..))
 }
 
 fn verify_external_operations(

--- a/modules/auth/src/core.rs
+++ b/modules/auth/src/core.rs
@@ -66,7 +66,11 @@ pub trait UtxoAuthorizable {
                 let sig_map = signatures.0.clone();
 
                 if cc.args.len() < 1 {
-                    return Ok(()); // No auth requirements, skip
+                    // MOON-03: a context with no auth-requirements arg carries no UTXO
+                    // requirements, but it must only skip THIS context — never short-circuit the
+                    // whole check. A `return Ok(())` here would let an empty-args context that
+                    // precedes a spend-bearing context bypass the latter's P256 verification.
+                    continue;
                 }
 
                 let v_req = cc.args.get(0).ok_or(Error::BadArg)?;

--- a/modules/auth/src/core.rs
+++ b/modules/auth/src/core.rs
@@ -8,6 +8,16 @@ use soroban_sdk::{
     TryIntoVal, Vec,
 };
 
+/// Verify a secp256r1 (P-256) signature.
+///
+/// # Safety / invariant (MOON-04)
+/// `secp256r1_verify` returns `()` and **panics (traps the transaction) on an invalid signature**;
+/// it never returns an error to inspect. This wrapper therefore returns `Ok(())` unconditionally
+/// and relies entirely on that panic-on-failure semantic of soroban-sdk 25.3.x — there is no
+/// success/failure value to branch on. If a future SDK changes these primitives to RETURN a
+/// result instead of panicking, this wrapper would silently accept invalid signatures and MUST be
+/// rewritten to check the returned value. The `signature_verification_*` regression tests lock the
+/// current behavior; re-validate them on every SDK upgrade.
 fn verify_p256_signature(
     e: &Env,
     public_key: &BytesN<65>,
@@ -20,6 +30,12 @@ fn verify_p256_signature(
     Ok(())
 }
 
+/// Verify an Ed25519 signature.
+///
+/// # Safety / invariant (MOON-04)
+/// See [`verify_p256_signature`]: `ed25519_verify` panics on an invalid signature and returns no
+/// inspectable result, so this wrapper depends on that panic-on-failure semantic. Re-validate on
+/// every SDK upgrade.
 fn verify_ed25519_signature(
     e: &Env,
     public_key: &BytesN<32>,

--- a/modules/auth/src/test.rs
+++ b/modules/auth/src/test.rs
@@ -267,3 +267,42 @@ fn test_handle_utxo_auth_empty_context_does_not_skip_later_spend_context() {
 
     assert_eq!(result, Err(MoonlightError::MissingSignature));
 }
+
+/// MOON-04: lock the panic-on-failure semantic the verifier wrappers depend on. An invalid P256
+/// signature (verified against a different payload than it signed) must panic / trap.
+#[test]
+#[should_panic]
+fn signature_verification_panics_on_invalid_p256_signature() {
+    let e = Env::default();
+    let kp = P256KeyPair::generate(&e);
+    let signed = e
+        .crypto()
+        .sha256(&soroban_sdk::Bytes::from_array(&e, b"the-signed-message"));
+    let other = e
+        .crypto()
+        .sha256(&soroban_sdk::Bytes::from_array(&e, b"a-different-message"));
+    let sig = kp.sign(&signed);
+    let signature = Signature::P256(soroban_sdk::BytesN::<64>::from_array(&e, &sig));
+    let signer = SignerKey::P256(kp.public_key.clone());
+
+    verify_signature(&e, &signer, &signature, &other).unwrap();
+}
+
+/// MOON-04: same lock for Ed25519.
+#[test]
+#[should_panic]
+fn signature_verification_panics_on_invalid_ed25519_signature() {
+    let e = Env::default();
+    let acc = Ed25519Account::generate(&e);
+    let signed = e
+        .crypto()
+        .sha256(&soroban_sdk::Bytes::from_array(&e, b"the-signed-message"));
+    let other = e
+        .crypto()
+        .sha256(&soroban_sdk::Bytes::from_array(&e, b"a-different-message"));
+    let sig = acc.sign(&e, signed.clone());
+    let signature = Signature::Ed25519(sig);
+    let signer = SignerKey::Ed25519(acc.public_key.clone());
+
+    verify_signature(&e, &signer, &signature, &other).unwrap();
+}

--- a/modules/auth/src/test.rs
+++ b/modules/auth/src/test.rs
@@ -1,8 +1,16 @@
+use moonlight_errors::Error as MoonlightError;
 use moonlight_helpers::testutils::keys::{Ed25519Account, P256KeyPair};
-use moonlight_primitives::{Condition, Signature, SignerKey};
-use soroban_sdk::{testutils::Ledger, vec, xdr, Env, Error, Map};
+use moonlight_primitives::{Condition, Signature, Signatures, SignerKey};
+use soroban_sdk::{
+    auth::{Context, ContractContext},
+    testutils::{Address as _, Ledger},
+    vec, xdr, Address, Env, Error, Map, Symbol,
+};
 
-use crate::{core::verify_signature, testutils::contract::create_contract};
+use crate::{
+    core::{verify_signature, UtxoAuthorizable},
+    testutils::contract::{create_contract, AuthModuleTestContract},
+};
 use moonlight_utxo_core::testutils::{
     contract::create_contract as create_utxo_contract, operation_bundle::UTXOOperationBuilder,
 };
@@ -213,4 +221,49 @@ fn test_ed25519_signatures() {
 
         verify_signature(&e, &signer, &signature, &hash).unwrap();
     }
+}
+
+/// MOON-03: an empty-args context must not short-circuit the whole `handle_utxo_auth` check.
+/// With the empty context placed FIRST, the following spend-bearing context must still be
+/// evaluated (and here fail `MissingSignature`, since no signature is supplied). Pre-fix the
+/// `return Ok(())` skipped it entirely and the call wrongly succeeded.
+#[test]
+fn test_handle_utxo_auth_empty_context_does_not_skip_later_spend_context() {
+    let e = Env::default();
+    let (auth_client, _) = create_contract(&e);
+    let channel = Address::generate(&e);
+    let utxo = P256KeyPair::generate(&e);
+
+    // A spend context that DOES require a P256 signature for `utxo`.
+    let mut builder =
+        UTXOOperationBuilder::generate(&e, channel.clone(), auth_client.address.clone());
+    builder.add_spend(
+        utxo.public_key.clone(),
+        vec![&e, Condition::Create(utxo.public_key.clone(), 100_i128)],
+    );
+    let spend_args = builder.get_contract_auth_args(&e);
+
+    let empty_ctx = Context::Contract(ContractContext {
+        contract: channel.clone(),
+        fn_name: Symbol::new(&e, "noop"),
+        args: vec![&e], // empty args => no requirements for this context
+    });
+    let spend_ctx = Context::Contract(ContractContext {
+        contract: channel.clone(),
+        fn_name: Symbol::new(&e, "transact"),
+        args: spend_args,
+    });
+
+    // No signatures supplied at all.
+    let signatures = Signatures(Map::new(&e));
+
+    let result = e.as_contract(&auth_client.address, || {
+        <AuthModuleTestContract as UtxoAuthorizable>::handle_utxo_auth(
+            &e,
+            signatures.clone(),
+            vec![&e, empty_ctx.clone(), spend_ctx.clone()],
+        )
+    });
+
+    assert_eq!(result, Err(MoonlightError::MissingSignature));
 }

--- a/modules/errors/src/lib.rs
+++ b/modules/errors/src/lib.rs
@@ -88,6 +88,8 @@ pub enum MoonlightError {
     UnauthorizedOperation = 3_006,
     /// A deposit or withdraw amount was not strictly positive.
     InvalidExternalAmount = 3_007,
+    /// `transact` was re-entered while a call was already in progress.
+    ReentrantCall = 3_008,
 
     // Helper errors: 4000-4099.
     /// An address payload was expected to be an Ed25519 account address but was not.

--- a/modules/errors/src/lib.rs
+++ b/modules/errors/src/lib.rs
@@ -86,6 +86,8 @@ pub enum MoonlightError {
     /// An executed create/withdraw effect is not covered by an owner-signed condition,
     /// or an owner-signed create/withdraw condition is not executed by the bundle.
     UnauthorizedOperation = 3_006,
+    /// A deposit or withdraw amount was not strictly positive.
+    InvalidExternalAmount = 3_007,
 
     // Helper errors: 4000-4099.
     /// An address payload was expected to be an Ed25519 account address but was not.

--- a/modules/errors/src/lib.rs
+++ b/modules/errors/src/lib.rs
@@ -83,6 +83,9 @@ pub enum MoonlightError {
     BundleHasConflictingConditions = 3_004,
     /// An amount calculation went below the minimum supported integer value.
     AmountUnderflow = 3_005,
+    /// An executed create/withdraw effect is not covered by an owner-signed condition,
+    /// or an owner-signed create/withdraw condition is not executed by the bundle.
+    UnauthorizedOperation = 3_006,
 
     // Helper errors: 4000-4099.
     /// An address payload was expected to be an Ed25519 account address but was not.

--- a/modules/storage/src/cache.rs
+++ b/modules/storage/src/cache.rs
@@ -23,14 +23,17 @@ impl DrawerCache {
         if self.state_dirty {
             if let Some(ref state) = self.state {
                 e.storage().persistent().set(&DrawerDataKey::State, state);
+                // MOON-02: keep the allocation-pointer entry alive.
+                Store::bump_drawer_ttl(e, &DrawerDataKey::State);
             }
         }
 
         for (drawer_id, _) in self.dirty_drawers.iter() {
             if let Some(bitmap) = self.drawers.get(drawer_id) {
-                e.storage()
-                    .persistent()
-                    .set(&Store::drawer_key(drawer_id), &bitmap);
+                let key = Store::drawer_key(drawer_id);
+                e.storage().persistent().set(&key, &bitmap);
+                // MOON-02: keep the shared drawer bitmap alive; archival would freeze the drawer.
+                Store::bump_drawer_ttl(e, &key);
             }
         }
     }

--- a/modules/storage/src/lib.rs
+++ b/modules/storage/src/lib.rs
@@ -67,6 +67,14 @@ impl Store {
     // One bitmap byte tracks 8 slots, rounded up if the drawer size changes.
     const BITMAP_BYTES: u32 = (Self::SLOTS_PER_DRAWER + 7) / 8;
 
+    // MOON-02: persistent-entry TTL management. UTXO metadata and drawer bitmaps back user funds,
+    // so they must outlive long idle periods; without an explicit bump they archive and an
+    // archived (shared) drawer bitmap would freeze every UTXO in that drawer until restored.
+    const DAY_IN_LEDGERS: u32 = 17_280;
+    const PERSISTENT_BUMP_AMOUNT: u32 = 30 * Self::DAY_IN_LEDGERS;
+    const PERSISTENT_LIFETIME_THRESHOLD: u32 =
+        Self::PERSISTENT_BUMP_AMOUNT - Self::DAY_IN_LEDGERS;
+
     /// Runs UTXO storage operations in a scoped drawer cache.
     ///
     /// The closure receives the only mutable handle to storage operations. Any
@@ -147,6 +155,7 @@ impl Store {
                 slot_idx,
             },
         );
+        self.bump_utxo_meta_ttl(&uk);
 
         let mut bitmap = self.get_or_create_bitmap(drawer_id);
         self.set_bit_in_bitmap(&mut bitmap, slot_idx, true);
@@ -173,6 +182,9 @@ impl Store {
                     panic_with_error!(&self.env, Error::UtxoAlreadySpent);
                 }
 
+                // Keep the spent-record alive so the UTXO cannot be recreated after archival.
+                self.bump_utxo_meta_ttl(&uk);
+
                 self.set_bit_in_bitmap(&mut bitmap, slot_idx, false);
                 self.cache.drawers.set(drawer_id, bitmap);
                 self.cache.dirty_drawers.set(drawer_id, true);
@@ -181,6 +193,24 @@ impl Store {
             }
             None => panic_with_error!(&self.env, Error::UtxoDoesNotExist),
         }
+    }
+
+    #[inline(always)]
+    fn bump_utxo_meta_ttl(&self, key: &UTXOCoreDataKey) {
+        self.env.storage().persistent().extend_ttl(
+            key,
+            Self::PERSISTENT_LIFETIME_THRESHOLD,
+            Self::PERSISTENT_BUMP_AMOUNT,
+        );
+    }
+
+    #[inline(always)]
+    pub(crate) fn bump_drawer_ttl(env: &Env, key: &DrawerDataKey) {
+        env.storage().persistent().extend_ttl(
+            key,
+            Self::PERSISTENT_LIFETIME_THRESHOLD,
+            Self::PERSISTENT_BUMP_AMOUNT,
+        );
     }
 
     #[inline(always)]

--- a/modules/storage/src/test.rs
+++ b/modules/storage/src/test.rs
@@ -1,3 +1,4 @@
+use soroban_sdk::testutils::storage::Persistent as _;
 use soroban_sdk::{contract, Address, Bytes, BytesN, Env};
 
 use crate::{hash_utxo_key, DrawerDataKey, DrawerState, Store, UTXOCoreDataKey, UtxoMeta};
@@ -205,6 +206,32 @@ fn rotates_to_the_next_drawer_when_the_current_drawer_is_full() {
         let bitmap = drawer_bitmap(&e, 2);
         assert_eq!(bitmap.len(), 1);
         assert_eq!(bitmap.get(0), Some(0b0000_0001));
+    });
+}
+
+#[test]
+fn create_and_spend_bump_persistent_ttl() {
+    // MOON-02: UTXO metadata, the shared drawer bitmap, and the allocation-state entry must be
+    // pushed to the long (30-day) TTL window so they cannot archive while the channel is live.
+    let e = Env::default();
+    let contract_id = storage_contract(&e);
+
+    in_contract(&e, &contract_id, || {
+        let key = utxo(&e, 1);
+        let uk = UTXOCoreDataKey::UTXO(hash_utxo_key(&e, &key));
+
+        Store::apply(&e, |store| store.create(&key, 100));
+
+        let min_ttl = Store::PERSISTENT_BUMP_AMOUNT - Store::DAY_IN_LEDGERS;
+        assert!(e.storage().persistent().get_ttl(&uk) >= min_ttl);
+        assert!(e.storage().persistent().get_ttl(&Store::drawer_key(1)) >= min_ttl);
+        assert!(e.storage().persistent().get_ttl(&DrawerDataKey::State) >= min_ttl);
+
+        // Spending keeps the now-spent record alive (so it cannot be recreated post-archival).
+        Store::apply(&e, |store| {
+            store.spend(&key);
+        });
+        assert!(e.storage().persistent().get_ttl(&uk) >= min_ttl);
     });
 }
 

--- a/modules/utxo-core/src/core.rs
+++ b/modules/utxo-core/src/core.rs
@@ -188,7 +188,7 @@ pub trait UtxoHandlerTrait {
         #[cfg(not(feature = "no-utxo-events"))]
         UtxoEvent {
             name: symbol_short!("utxo"),
-            utxo,
+            utxo: utxo.clone(),
             action: symbol_short!("create"),
             amount,
         }

--- a/modules/utxo-core/src/events.rs
+++ b/modules/utxo-core/src/events.rs
@@ -1,8 +1,13 @@
-#[cfg(not(feature = "no-bundle-events"))]
-use soroban_sdk::{contractevent, BytesN, Symbol, Vec};
-
-#[cfg(not(feature = "no-utxo-events"))]
+// MOON-10: import the shared names once across either feature so enabling events does not produce
+// duplicate-import compile errors. `Vec` is only needed by the bundle event.
+#[cfg(any(
+    not(feature = "no-bundle-events"),
+    not(feature = "no-utxo-events")
+))]
 use soroban_sdk::{contractevent, BytesN, Symbol};
+
+#[cfg(not(feature = "no-bundle-events"))]
+use soroban_sdk::Vec;
 
 #[cfg(not(feature = "no-bundle-events"))]
 #[contractevent(data_format = "vec")]


### PR DESCRIPTION
Remediates the preemptive internal audit (`pm-theahaco/audits/preempt-soroban-2026-06-11/AUDIT-REPORT.md`) ahead of the RV engagement. One commit per finding for traceability.

## Findings → commits

| Audit ID | Severity | Commit | What |
|---|---|---|---|
| MOON-01 | Critical | `53bc4ee` + `8ad0f37` | Bind owner-signed `Create`/`ExtWithdraw` conditions to executed effects (subset `authorized ⊆ executed`); balance check retained. `8ad0f37` relaxes the initial exact-match to subset so the provider fee is permitted (see below). |
| MOON-02 | Medium | `07a4790` | Manage storage TTL — bump persistent UTXO meta / drawer bitmap / state and the contract instance so live state can't archive. |
| MOON-03 | Low | `c3dd832` | `handle_utxo_auth` empty-args context now `continue`s instead of `return Ok(())` (no whole-check short-circuit). |
| MOON-04 | Low | `04d6b95` | Document + lock (regression tests) the verifier wrappers' dependence on host panic-on-failure. |
| MOON-05 | Low | `c7e0256` | Reject non-positive deposit/withdraw amounts in-contract (`InvalidExternalAmount`). |
| MOON-06 | Low | `9a4d172` | Reentrancy guard around `transact` (`ReentrantCall`). |
| MOON-09 | Info | `866f331` | Emit `Upgraded { wasm_hash }` on upgrade (governance trail). |
| MOON-10 | Info | `9ea90cf` | Make the utxo-core events feature compile (dedup imports + `&BytesN` fix). |
| — | — | `5f5ea6a` | Version bump `0.2.0 → 0.2.1` (auto-tag). |

**Deferred (flagged in the audit):** MOON-07 (64 KiB drawer bitmap vs entry-size — needs protocol-limit confirmation), MOON-08 (`ExtIntegration` removal/impl — roadmap; the MOON-01 binding already makes it inert), MOON-09 constructor-auth alignment (changes deploy behavior — separate PM call), MOON-11 (dep patch-bumps + `# Panics` docs — not touching the audited dep stack pre-RV).

## MOON-01 — the Critical, with adversarial pre/post proof

The balance check alone (`total_available_balance == expected_outgoing`) guarantees value conservation but not *where* value goes. A provider could keep `op.spend` byte-identical (the owner's P256 sig still verifies over the unchanged conditions) and substitute `op.create`/`op.withdraw` to redirect funds while staying balanced → theft. The fix requires every owner-signed `Create`/`ExtWithdraw` to be executed exactly (same utxo/addr + amount); extra executed creates/withdraws are allowed (the provider fee) and bounded by the balance check to the residual the signers leave.

Adversarial test (`contracts/privacy-channel/src/test/moon01.rs`): a victim signs a spend authorizing an internal change-create, the bundle keeps `op.spend` byte-identical but redirects the output to an attacker, perfectly balanced.

- **PRE-FIX** (binding disabled): `transact` **ACCEPTED** — victim UTXO spent, attacker token balance `+500`, channel supply drained to `0`.
- **POST-FIX** (subset binding): same bundle **REJECTED** with `UnauthorizedOperation` — victim UTXO still `500`, attacker `0`, supply `500`.

Also covered: redirect-to-attacker-create rejects; a within-residual provider fee is accepted (the real e2e shape); taking more than the residual or adding any extra create to a residual-0 transfer reverts via `UnbalancedBundle`.

## Why subset, not exact-match
The real fee model has the provider executor add an **unsigned** `Create(opexUtxo, fee)` to collect the residual the depositor over-funds / spender under-claims (`provider-platform/.../executor.service.ts:81`); the client deposits `amount + fee` but signs a condition only for `amount`. Exact-match rejected that legitimate fee create (caught by the e2e). Subset keeps signed outputs inviolable while permitting the fee.

## Validation
- `cargo test --workspace`: **61 passed / 0 failed**. `cargo clippy --all-targets`: clean. `stellar contract build`: both wasms.
- **local-dev e2e against the fixed WASM: PASS** — full payment flow (deposit 10 XLM → send 5 Alice→Bob → withdraw 4) completes with the real provider fee model, while the adversarial redirect stays rejected.

## ⚠ Downstream (separate PM ops — NOT in this PR)
- The fixed WASM must be **redeployed + re-initialized** on testnet (then mainnet / D8).
- **Before that redeploy:** confirm **browser-wallet** and **provider-platform** bundle assembly attaches exact-mirror conditions for every executed user create/withdraw — otherwise the tightened contract will reject their bundles. (The local-dev reference client + executor already conform, verified by the e2e; the other consumers must be checked.)
