### PR TITLE
chore(toolchain): declare wasm32v1-none target in rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.96.1"
+targets = ["wasm32v1-none"]


### PR DESCRIPTION
## What

Adds `targets = ["wasm32v1-none"]` to `rust-toolchain.toml`.

## Why

#36 pinned the Rust **channel** (`1.96.1`) but not the target. On a fresh checkout that means `stellar contract build` / `cargo build --target wasm32v1-none` fails until you manually run `rustup target add wasm32v1-none` — which is exactly what came up validating the pinned build locally. Declaring the target in the toolchain file makes rustup install it automatically, so a clean clone builds the contracts with no manual step. (CI already installs the target via `dtolnay/rust-toolchain`, so this mainly fixes local/onboarding builds.)

## Scope

Build-config only — one line. No `Cargo.toml`/version change, and no effect on compiled wasm bytes (a target declaration only controls what rustup installs, not codegen). Follow-on to #36.