### PR TITLE
fix(utxo-core): checked arithmetic on conservation accumulator (B2)

### DIFF
--- a/modules/utxo-core/src/core.rs
+++ b/modules/utxo-core/src/core.rs
@@ -101,7 +101,13 @@ pub trait UtxoHandlerTrait {
                 };
 
                 store.spend(&spend_utxo);
-                total_available_balance += amount;
+                // B2: keep value conservation correct-by-construction — this library may be
+                // compiled with overflow-checks off, so guard the accumulator explicitly rather
+                // than relying on the env's overflow panic.
+                total_available_balance = match total_available_balance.checked_add(amount) {
+                    Some(v) => v,
+                    None => panic_with_error!(e, MoonlightError::AmountOverflow),
+                };
 
                 #[cfg(not(feature = "no-utxo-events"))]
                 UtxoEvent {
@@ -121,7 +127,12 @@ pub trait UtxoHandlerTrait {
                 assert_with_error!(&e, amount > 0, MoonlightError::InvalidCreateAmount);
 
                 store.create(&create_utxo, amount);
-                total_available_balance -= amount;
+                // B2: see the spend accumulator above — guard the subtraction explicitly so the
+                // conservation invariant does not depend on the consumer's overflow-checks profile.
+                total_available_balance = match total_available_balance.checked_sub(amount) {
+                    Some(v) => v,
+                    None => panic_with_error!(e, MoonlightError::AmountUnderflow),
+                };
 
                 #[cfg(not(feature = "no-utxo-events"))]
                 UtxoEvent {

--- a/modules/utxo-core/src/tests/test.rs
+++ b/modules/utxo-core/src/tests/test.rs
@@ -550,3 +550,67 @@ fn test_transfer_with_additional_auth_conditions() {
     assert_eq!(client.utxo_balance(&utxo_d.public_key.clone()), 450_i128);
     assert_eq!(client.utxo_balance(&utxo_e.public_key.clone()), 450_i128);
 }
+
+// B2: the conservation accumulator uses checked_add on the spend side, so a bundle whose input
+// sum exceeds i128::MAX yields the mapped AmountOverflow error instead of depending on the
+// environment's overflow panic (which a consumer compiling with overflow-checks off would lose).
+#[test]
+fn test_process_bundle_accumulator_overflow() {
+    let e = Env::default();
+    let (client, _) = create_contract_with_mocked_auth(&e);
+
+    let utxo_a = P256KeyPair::generate(&e);
+    let utxo_b = P256KeyPair::generate(&e);
+
+    // Two inputs whose sum overflows i128 once accumulated.
+    client.mint(&vec![&e, (utxo_a.public_key.clone(), i128::MAX)]);
+    client.mint(&vec![&e, (utxo_b.public_key.clone(), i128::MAX)]);
+
+    let op = UTXOOperation {
+        create: vec![&e],
+        spend: vec![
+            &e,
+            (utxo_a.public_key.clone(), vec![&e]),
+            (utxo_b.public_key.clone(), vec![&e]),
+        ],
+    };
+
+    let overflow_error = client.mock_all_auths().try_transact(&op);
+
+    assert_eq!(
+        overflow_error.err(),
+        Some(Ok(Error::from_contract_error(
+            ContractError::AmountOverflow as u32
+        )))
+    );
+}
+
+// B2: the create side uses checked_sub, so a bundle whose created amounts drive the accumulator
+// below i128::MIN yields the mapped AmountUnderflow error rather than relying on the env panic.
+#[test]
+fn test_process_bundle_accumulator_underflow() {
+    let e = Env::default();
+    let (client, _) = create_contract_with_mocked_auth(&e);
+
+    let utxo_a = P256KeyPair::generate(&e);
+    let utxo_b = P256KeyPair::generate(&e);
+
+    // No inputs; two creates near i128::MAX subtract past i128::MIN.
+    let op = UTXOOperation {
+        create: vec![
+            &e,
+            (utxo_a.public_key.clone(), i128::MAX),
+            (utxo_b.public_key.clone(), i128::MAX),
+        ],
+        spend: vec![&e],
+    };
+
+    let underflow_error = client.mock_all_auths().try_transact(&op);
+
+    assert_eq!(
+        underflow_error.err(),
+        Some(Ok(Error::from_contract_error(
+            ContractError::AmountUnderflow as u32
+        )))
+    );
+}


### PR DESCRIPTION
## Audit finding B2 (informational)

`utxo-core`'s `process_bundle` maintains the value-conservation running total (`total_available_balance`) with raw `+=` / `-=`, then asserts `total_available_balance == expected_outgoing`. As shipped this is safe — the runtime's overflow-checks panic-and-revert on overflow. But `utxo-core` is a **reusable library** exposed to arbitrary integrating contracts; a consumer that compiles it with overflow-checks off would silently reintroduce wrap-around arithmetic on the protocol's central invariant. A core safety property shouldn't depend on the linker's build profile.

## Change

- `process_bundle`: replace the accumulator's raw `+=` / `-=` with `checked_add` / `checked_sub`, mapping failure to the existing `AmountOverflow` / `AmountUnderflow` variants — mirroring the defensive summation already used in `pre_process_channel_operation` (`transact.rs`). Makes conservation correct-by-construction regardless of compile profile.
- Behavior on all valid bundles is **identical**; only the overflow/underflow edge moves from an env panic to an explicit mapped error. The conservation check itself is unchanged.

## Tests

- `test_process_bundle_accumulator_overflow`: two inputs summing past `i128::MAX` → `AmountOverflow`.
- `test_process_bundle_accumulator_underflow`: creates driving the accumulator below `i128::MIN` → `AmountUnderflow`.
- Both prove the mapped error fires independent of the env's overflow panic. Existing `process_bundle` / conservation tests still pass (`cargo test --workspace`: 64/0).

## Verification

- `cargo test --workspace`: 64 passed, 0 failed.
- `stellar contract build`: both WASMs build.
- `cargo fmt`/`clippy`: clean on changed code.

## Downstream

Merging bumps the workspace version to `0.4.1` (auto-tag → release). SDK / consumer bumps on the release are **not** included here.