### PR TITLE
fix: bound set_admin acceptance window (B1)

### DIFF
--- a/contracts/channel-auth/src/contract.rs
+++ b/contracts/channel-auth/src/contract.rs
@@ -6,7 +6,7 @@ use soroban_sdk::{
     auth::{Context, CustomAccountInterface},
     contract, contractevent, contractimpl,
     crypto::Hash,
-    Address, BytesN, Env, Vec,
+    panic_with_error, Address, BytesN, Env, Vec,
 };
 use stellar_access::ownable;
 use stellar_contract_utils::upgradeable;
@@ -62,6 +62,11 @@ const DAY_IN_LEDGERS: u32 = 17_280;
 const INSTANCE_BUMP_AMOUNT: u32 = 7 * DAY_IN_LEDGERS;
 const INSTANCE_LIFETIME_THRESHOLD: u32 = INSTANCE_BUMP_AMOUNT - DAY_IN_LEDGERS;
 
+// Cap the acceptance window of a pending ownership transfer in-contract. Without this the
+// window could run to the network max (~180 days), leaving a compromised pending key exploitable
+// for months. 7 days is the hard ceiling; the standard operating value is 3 days (see `set_admin`).
+const MAX_ACCEPTANCE_WINDOW: u32 = 7 * DAY_IN_LEDGERS;
+
 fn bump_instance_ttl(e: &Env) {
     e.storage()
         .instance()
@@ -83,8 +88,25 @@ impl ChannelAuthContract {
         ownable::get_owner(e).unwrap()
     }
 
-    pub fn set_admin(e: &Env, new_admin: Address) {
-        ownable::transfer_ownership(e, &new_admin, e.ledger().max_live_until_ledger());
+    /// Initiate a two-step transfer of the admin (owner) role to `new_admin`.
+    ///
+    /// `live_until_ledger` is the ledger up to which `new_admin` may `accept_admin`. Pass
+    /// `current_ledger + N`, where `N` is the acceptance window in ledgers. The standard window
+    /// for a real ownership handover is **3 days** = `current_ledger + 3 * DAY_IN_LEDGERS`
+    /// (51_840 ledgers); the sensible range is 24h (17_280) to 7d (120_960). There is deliberately
+    /// no default — every call states its window explicitly.
+    ///
+    /// A non-zero window beyond the in-contract ceiling of 7 days (`MAX_ACCEPTANCE_WINDOW` =
+    /// 120_960 ledgers past the current ledger) panics [`MoonlightError::AcceptanceWindowTooLong`].
+    /// `live_until_ledger == 0` is exempt from the ceiling and cancels a pending transfer (the
+    /// library requires the cancel call to name the current pending address).
+    pub fn set_admin(e: &Env, new_admin: Address, live_until_ledger: u32) {
+        if live_until_ledger != 0
+            && live_until_ledger > e.ledger().sequence() + MAX_ACCEPTANCE_WINDOW
+        {
+            panic_with_error!(e, MoonlightError::AcceptanceWindowTooLong);
+        }
+        ownable::transfer_ownership(e, &new_admin, live_until_ledger);
     }
 
     pub fn accept_admin(e: &Env) {

--- a/contracts/channel-auth/src/tests/tests.rs
+++ b/contracts/channel-auth/src/tests/tests.rs
@@ -1,10 +1,11 @@
 #![cfg(test)]
 
+use moonlight_errors::Error as ContractError;
 use moonlight_helpers::testutils::keys::{Ed25519Account, P256KeyPair};
 use moonlight_primitives::Condition;
 use soroban_sdk::{
     testutils::{Address as _, MockAuth, MockAuthInvoke},
-    vec, Address, Env, IntoVal,
+    vec, Address, Env, Error as SorobanError, IntoVal,
 };
 
 use crate::contract::{ChannelAuthContract, ChannelAuthContractArgs, ChannelAuthContractClient};
@@ -31,17 +32,18 @@ fn test_admin_transfer_keeps_current_admin_in_control_until_acceptance() {
     let provider = Address::generate(&e);
     let blocked_provider = Address::generate(&e);
 
+    let live_until = e.ledger().sequence() + 3 * 17_280;
     auth_client
         .mock_auths(&[MockAuth {
             address: &admin,
             invoke: &MockAuthInvoke {
                 contract: &auth_client.address,
                 fn_name: "set_admin",
-                args: (&pending_admin,).into_val(&e),
+                args: (&pending_admin, live_until).into_val(&e),
                 sub_invokes: &[],
             },
         }])
-        .set_admin(&pending_admin);
+        .set_admin(&pending_admin, &live_until);
 
     assert_eq!(auth_client.admin(), admin.clone());
 
@@ -84,17 +86,18 @@ fn test_admin_transfer_requires_pending_admin_to_accept() {
     let old_admin_provider = Address::generate(&e);
     let new_admin_provider = Address::generate(&e);
 
+    let live_until = e.ledger().sequence() + 3 * 17_280;
     auth_client
         .mock_auths(&[MockAuth {
             address: &admin,
             invoke: &MockAuthInvoke {
                 contract: &auth_client.address,
                 fn_name: "set_admin",
-                args: (&pending_admin,).into_val(&e),
+                args: (&pending_admin, live_until).into_val(&e),
                 sub_invokes: &[],
             },
         }])
-        .set_admin(&pending_admin);
+        .set_admin(&pending_admin, &live_until);
 
     let non_pending_accept = auth_client
         .mock_auths(&[MockAuth {
@@ -153,6 +156,100 @@ fn test_admin_transfer_requires_pending_admin_to_accept() {
         .add_provider(&new_admin_provider);
 
     assert!(auth_client.is_provider(&new_admin_provider));
+}
+
+#[test]
+fn test_set_admin_enforces_acceptance_window_ceiling() {
+    let e = Env::default();
+    let (auth_client, admin) = create_contract(&e);
+    let pending_admin = Address::generate(&e);
+
+    // 7-day ceiling = current + 7 * DAY_IN_LEDGERS = current + 120_960.
+    let max_window = e.ledger().sequence() + 7 * 17_280;
+
+    // Exactly at the ceiling: accepted; admin stays until the pending transfer is accepted.
+    auth_client
+        .mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &auth_client.address,
+                fn_name: "set_admin",
+                args: (&pending_admin, max_window).into_val(&e),
+                sub_invokes: &[],
+            },
+        }])
+        .set_admin(&pending_admin, &max_window);
+    assert_eq!(auth_client.admin(), admin.clone());
+
+    // One ledger past the ceiling: rejected with AcceptanceWindowTooLong.
+    let too_long = max_window + 1;
+    let res = auth_client
+        .mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &auth_client.address,
+                fn_name: "set_admin",
+                args: (&pending_admin, too_long).into_val(&e),
+                sub_invokes: &[],
+            },
+        }])
+        .try_set_admin(&pending_admin, &too_long);
+    assert_eq!(
+        res.err(),
+        Some(Ok(SorobanError::from_contract_error(
+            ContractError::AcceptanceWindowTooLong as u32
+        )))
+    );
+}
+
+#[test]
+fn test_set_admin_zero_cancels_pending_transfer() {
+    let e = Env::default();
+    let (auth_client, admin) = create_contract(&e);
+    let pending_admin = Address::generate(&e);
+
+    // Initiate a transfer within the window.
+    let live_until = e.ledger().sequence() + 3 * 17_280;
+    auth_client
+        .mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &auth_client.address,
+                fn_name: "set_admin",
+                args: (&pending_admin, live_until).into_val(&e),
+                sub_invokes: &[],
+            },
+        }])
+        .set_admin(&pending_admin, &live_until);
+
+    // Cancel it: name the current pending address with live_until_ledger = 0 (ceiling-exempt).
+    let zero: u32 = 0;
+    auth_client
+        .mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &auth_client.address,
+                fn_name: "set_admin",
+                args: (&pending_admin, zero).into_val(&e),
+                sub_invokes: &[],
+            },
+        }])
+        .set_admin(&pending_admin, &zero);
+
+    // The transfer is gone: the formerly-pending admin can no longer accept, admin is unchanged.
+    let accept = auth_client
+        .mock_auths(&[MockAuth {
+            address: &pending_admin,
+            invoke: &MockAuthInvoke {
+                contract: &auth_client.address,
+                fn_name: "accept_admin",
+                args: ().into_val(&e),
+                sub_invokes: &[],
+            },
+        }])
+        .try_accept_admin();
+    assert!(accept.is_err());
+    assert_eq!(auth_client.admin(), admin.clone());
 }
 
 #[test]

--- a/contracts/privacy-channel/src/contract.rs
+++ b/contracts/privacy-channel/src/contract.rs
@@ -30,6 +30,11 @@ const DAY_IN_LEDGERS: u32 = 17_280;
 const INSTANCE_BUMP_AMOUNT: u32 = 7 * DAY_IN_LEDGERS;
 const INSTANCE_LIFETIME_THRESHOLD: u32 = INSTANCE_BUMP_AMOUNT - DAY_IN_LEDGERS;
 
+// Cap the acceptance window of a pending ownership transfer in-contract. Without this the
+// window could run to the network max (~180 days), leaving a compromised pending key exploitable
+// for months. 7 days is the hard ceiling; the standard operating value is 3 days (see `set_admin`).
+const MAX_ACCEPTANCE_WINDOW: u32 = 7 * DAY_IN_LEDGERS;
+
 fn bump_instance_ttl(e: &Env) {
     e.storage()
         .instance()
@@ -67,8 +72,25 @@ impl PrivacyChannelContract {
         ownable::get_owner(e).unwrap()
     }
 
-    pub fn set_admin(e: &Env, new_admin: Address) {
-        ownable::transfer_ownership(e, &new_admin, e.ledger().max_live_until_ledger());
+    /// Initiate a two-step transfer of the admin (owner) role to `new_admin`.
+    ///
+    /// `live_until_ledger` is the ledger up to which `new_admin` may `accept_admin`. Pass
+    /// `current_ledger + N`, where `N` is the acceptance window in ledgers. The standard window
+    /// for a real ownership handover is **3 days** = `current_ledger + 3 * DAY_IN_LEDGERS`
+    /// (51_840 ledgers); the sensible range is 24h (17_280) to 7d (120_960). There is deliberately
+    /// no default — every call states its window explicitly.
+    ///
+    /// A non-zero window beyond the in-contract ceiling of 7 days (`MAX_ACCEPTANCE_WINDOW` =
+    /// 120_960 ledgers past the current ledger) panics [`Error::AcceptanceWindowTooLong`].
+    /// `live_until_ledger == 0` is exempt from the ceiling and cancels a pending transfer (the
+    /// library requires the cancel call to name the current pending address).
+    pub fn set_admin(e: &Env, new_admin: Address, live_until_ledger: u32) {
+        if live_until_ledger != 0
+            && live_until_ledger > e.ledger().sequence() + MAX_ACCEPTANCE_WINDOW
+        {
+            panic_with_error!(e, Error::AcceptanceWindowTooLong);
+        }
+        ownable::transfer_ownership(e, &new_admin, live_until_ledger);
     }
 
     pub fn accept_admin(e: &Env) {

--- a/contracts/privacy-channel/src/test/test.rs
+++ b/contracts/privacy-channel/src/test/test.rs
@@ -10,6 +10,7 @@ use channel_auth_contract::contract::{
     ChannelAuthContract, ChannelAuthContractArgs, ChannelAuthContractClient,
 };
 
+use moonlight_errors::Error as ContractError;
 use moonlight_helpers::testutils::{
     keys::P256KeyPair,
     snapshot::{get_env_with_g_accounts, get_snapshot_g_accounts},
@@ -17,7 +18,7 @@ use moonlight_helpers::testutils::{
 use moonlight_primitives::Condition;
 use soroban_sdk::{
     testutils::{Address as _, Ledger, MockAuth, MockAuthInvoke},
-    vec, Address, Env, FromVal, IntoVal, String,
+    vec, Address, Env, Error as SorobanError, FromVal, IntoVal, String,
 };
 
 use token_contract::{TestToken as Token, TestTokenClient as TokenClient};
@@ -71,6 +72,7 @@ fn test_admin_transfer_keeps_current_admin_until_acceptance() {
     let (channel, _, _, admin) = create_contracts(&e);
     let pending_admin = Address::generate(&e);
     let next_admin = Address::generate(&e);
+    let live_until = e.ledger().sequence() + 3 * 17_280;
 
     channel
         .mock_auths(&[MockAuth {
@@ -78,11 +80,11 @@ fn test_admin_transfer_keeps_current_admin_until_acceptance() {
             invoke: &MockAuthInvoke {
                 contract: &channel.address,
                 fn_name: "set_admin",
-                args: (&pending_admin,).into_val(&e),
+                args: (&pending_admin, live_until).into_val(&e),
                 sub_invokes: &[],
             },
         }])
-        .set_admin(&pending_admin);
+        .set_admin(&pending_admin, &live_until);
 
     assert_eq!(channel.admin(), admin.clone());
 
@@ -92,11 +94,11 @@ fn test_admin_transfer_keeps_current_admin_until_acceptance() {
             invoke: &MockAuthInvoke {
                 contract: &channel.address,
                 fn_name: "set_admin",
-                args: (&next_admin,).into_val(&e),
+                args: (&next_admin, live_until).into_val(&e),
                 sub_invokes: &[],
             },
         }])
-        .try_set_admin(&next_admin);
+        .try_set_admin(&next_admin, &live_until);
 
     assert!(pending_admin_set_admin.is_err());
     assert_eq!(channel.admin(), admin);
@@ -109,6 +111,7 @@ fn test_admin_transfer_requires_pending_admin_to_accept() {
     let pending_admin = Address::generate(&e);
     let non_pending_admin = Address::generate(&e);
     let next_admin = Address::generate(&e);
+    let live_until = e.ledger().sequence() + 3 * 17_280;
 
     channel
         .mock_auths(&[MockAuth {
@@ -116,11 +119,11 @@ fn test_admin_transfer_requires_pending_admin_to_accept() {
             invoke: &MockAuthInvoke {
                 contract: &channel.address,
                 fn_name: "set_admin",
-                args: (&pending_admin,).into_val(&e),
+                args: (&pending_admin, live_until).into_val(&e),
                 sub_invokes: &[],
             },
         }])
-        .set_admin(&pending_admin);
+        .set_admin(&pending_admin, &live_until);
 
     let non_pending_accept = channel
         .mock_auths(&[MockAuth {
@@ -157,11 +160,11 @@ fn test_admin_transfer_requires_pending_admin_to_accept() {
             invoke: &MockAuthInvoke {
                 contract: &channel.address,
                 fn_name: "set_admin",
-                args: (&next_admin,).into_val(&e),
+                args: (&next_admin, live_until).into_val(&e),
                 sub_invokes: &[],
             },
         }])
-        .try_set_admin(&next_admin);
+        .try_set_admin(&next_admin, &live_until);
 
     assert!(old_admin_set_admin.is_err());
     assert_eq!(channel.admin(), pending_admin.clone());
@@ -172,13 +175,107 @@ fn test_admin_transfer_requires_pending_admin_to_accept() {
             invoke: &MockAuthInvoke {
                 contract: &channel.address,
                 fn_name: "set_admin",
-                args: (&next_admin,).into_val(&e),
+                args: (&next_admin, live_until).into_val(&e),
                 sub_invokes: &[],
             },
         }])
-        .set_admin(&next_admin);
+        .set_admin(&next_admin, &live_until);
 
     assert_eq!(channel.admin(), pending_admin);
+}
+
+#[test]
+fn test_set_admin_enforces_acceptance_window_ceiling() {
+    let e = Env::default();
+    let (channel, _, _, admin) = create_contracts(&e);
+    let pending_admin = Address::generate(&e);
+
+    // 7-day ceiling = current + 7 * DAY_IN_LEDGERS = current + 120_960.
+    let max_window = e.ledger().sequence() + 7 * 17_280;
+
+    // Exactly at the ceiling: accepted; admin stays until the pending transfer is accepted.
+    channel
+        .mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &channel.address,
+                fn_name: "set_admin",
+                args: (&pending_admin, max_window).into_val(&e),
+                sub_invokes: &[],
+            },
+        }])
+        .set_admin(&pending_admin, &max_window);
+    assert_eq!(channel.admin(), admin.clone());
+
+    // One ledger past the ceiling: rejected with AcceptanceWindowTooLong.
+    let too_long = max_window + 1;
+    let res = channel
+        .mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &channel.address,
+                fn_name: "set_admin",
+                args: (&pending_admin, too_long).into_val(&e),
+                sub_invokes: &[],
+            },
+        }])
+        .try_set_admin(&pending_admin, &too_long);
+    assert_eq!(
+        res.err(),
+        Some(Ok(SorobanError::from_contract_error(
+            ContractError::AcceptanceWindowTooLong as u32
+        )))
+    );
+}
+
+#[test]
+fn test_set_admin_zero_cancels_pending_transfer() {
+    let e = Env::default();
+    let (channel, _, _, admin) = create_contracts(&e);
+    let pending_admin = Address::generate(&e);
+
+    // Initiate a transfer within the window.
+    let live_until = e.ledger().sequence() + 3 * 17_280;
+    channel
+        .mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &channel.address,
+                fn_name: "set_admin",
+                args: (&pending_admin, live_until).into_val(&e),
+                sub_invokes: &[],
+            },
+        }])
+        .set_admin(&pending_admin, &live_until);
+
+    // Cancel it: name the current pending address with live_until_ledger = 0 (ceiling-exempt).
+    let zero: u32 = 0;
+    channel
+        .mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &MockAuthInvoke {
+                contract: &channel.address,
+                fn_name: "set_admin",
+                args: (&pending_admin, zero).into_val(&e),
+                sub_invokes: &[],
+            },
+        }])
+        .set_admin(&pending_admin, &zero);
+
+    // The transfer is gone: the formerly-pending admin can no longer accept, admin is unchanged.
+    let accept = channel
+        .mock_auths(&[MockAuth {
+            address: &pending_admin,
+            invoke: &MockAuthInvoke {
+                contract: &channel.address,
+                fn_name: "accept_admin",
+                args: ().into_val(&e),
+                sub_invokes: &[],
+            },
+        }])
+        .try_accept_admin();
+    assert!(accept.is_err());
+    assert_eq!(channel.admin(), admin.clone());
 }
 
 #[test]

--- a/modules/errors/src/lib.rs
+++ b/modules/errors/src/lib.rs
@@ -47,6 +47,9 @@ pub enum MoonlightError {
     ProviderAlreadyRegistered = 1_012,
     /// The provider account is not registered.
     ProviderNotRegistered = 1_013,
+    /// A `set_admin` acceptance window exceeded the in-contract ceiling (7 days) for a
+    /// pending ownership transfer.
+    AcceptanceWindowTooLong = 1_014,
 
     // UTXO Module errors: 2000-2099.
     /// A UTXO creation attempted to write an output identifier that already exists.

--- a/modules/errors/src/test.rs
+++ b/modules/errors/src/test.rs
@@ -22,6 +22,7 @@ fn keeps_auth_errors_in_their_reserved_range() {
         Error::ProviderThresholdNotMet.code(),
         Error::ProviderAlreadyRegistered.code(),
         Error::ProviderNotRegistered.code(),
+        Error::AcceptanceWindowTooLong.code(),
     ] {
         assert!((1_000..=1_099).contains(&code));
     }


### PR DESCRIPTION
## What

Both `channel-auth` and `privacy-channel` had `set_admin(new_admin)` call `ownable::transfer_ownership(e, &new_admin, e.ledger().max_live_until_ledger())`, hardcoding the acceptance window of a pending ownership transfer to the network max (~180 days). A pending transfer therefore never auto-expired, so a `PendingOwner` key compromised while a transfer lingered stayed exploitable for months, and the library's `0`-cancel path was unreachable.

Approved fix (RV audit finding **B1**):

- `set_admin(e, new_admin, live_until_ledger: u32)` — **required** parameter, forwarded to `transfer_ownership`. No default, so `max` can never silently return.
- **In-contract 7-day ceiling:** a non-zero `live_until_ledger` beyond `current_ledger + 7 * DAY_IN_LEDGERS` (120_960 ledgers) panics the new `MoonlightError::AcceptanceWindowTooLong` (code 1014). Panics rather than silently clamping.
- `live_until_ledger == 0` is **exempt** from the ceiling and preserves the library's cancel path (cancel names the current pending address).
- The two-step `accept_admin` and cancel semantics are unchanged — the ceiling is a tighter check layered on top of the library's existing `< current` / `> max` validation.
- The standard operating window for a real handover is **3 days** (`current_ledger + 3 * DAY_IN_LEDGERS` = 51_840 ledgers), documented on `set_admin`; sensible range 24h–7d. Both contracts get the identical change.

## Tests

- New (both contracts): boundary — `current + 120_960` accepted, `+1` rejects with `AcceptanceWindowTooLong`; `0` cancels a pending transfer (formerly-pending admin can no longer accept).
- Existing two-step accept/reject and admin-transfer tests updated to the new signature and still pass.
- `cargo test --workspace`: 66 passed / 0 failed. Both WASMs build (`stellar contract build`). fmt/clippy clean on changed code.

## Notes

- **Breaking ABI change** to `set_admin`. Downstream cascade (handled separately after merge, NOT in this PR): regenerate SDK/TS bindings, bump SDK + consumers, update ops/deploy scripts that call `set_admin`, redeploy + re-init the WASMs.
- Held for internal review — do not merge yet.

Refs audit finding B1.