### PR TITLE
Address RV audit informationals B6-B9 (provider/auth layer)

### DIFF
--- a/contracts/arch.md
+++ b/contracts/arch.md
@@ -286,6 +286,12 @@ The contracts are intended to uphold each of the following invariants. Where the
 
 Known invariant gap in CA-7: `upgrade` does not emit an explicit Moonlight event from this contract; its audit trail relies on the Stellar transaction record itself. Admin transfer uses OpenZeppelin Ownable events.
 
+Known constraint on CA-2/CA-3 (RV audit B6, accepted): the `valid_until_ledger` paired with each provider signature in the `Signatures` map is **submitter-supplied, not provider-signed** — the provider's Ed25519 signature covers only `payload`, the host's authorization-entry preimage, whose `signature_expiration_ledger` the host itself enforces. The binding provider deadline is that host-layer one; the in-contract expiry check in `require_provider` is a second, non-binding deadline the submitter can set freely. No security impact — the risk is misreading the in-contract field as a provider commitment.
+
+Known constraint on CA-4 (RV audit B8, accepted — deliberate, MOON-03): an argument-less `Context::Contract` carries no `AuthRequirements`, so `handle_utxo_auth` skips it and its only gate is the single provider signature verified by `require_provider`. This is intended for the channel's spend-free path (bundles with no UTXO spends). A contract should name this Channel Auth account as authorizer only where a one-provider-signature gate on an argument-less invocation is acceptable.
+
+Known constraint on CA-4 (RV audit B9, accepted): the P256 signatures verified by `handle_utxo_auth` carry **no replay protection of their own** — `__check_auth` keeps no nonce or used-signature state, so an identical (conditions, `valid_until_ledger`, signature) tuple verifies again on every call until expiry. Single-use is provided by the requesting contract, not by `__check_auth`: the Privacy Channel tombstones each spent UTXO, so a replayed spend fails there. Any other contract naming this account as authorizer must supply its own single-use mechanism.
+
 ### 4.2 Privacy Channel invariants
 
 - **PC-1 (immutable asset binding).** Once set in the constructor, `Asset` is never overwritten by any code path. The only writer is `write_asset_unchecked`, which is only called from `__constructor`. There is no setter exposed externally. *Enforced by code structure.*

--- a/contracts/channel-auth/Cargo.toml
+++ b/contracts/channel-auth/Cargo.toml
@@ -17,6 +17,7 @@ stellar-access = { workspace = true }
 stellar-contract-utils = { workspace = true }
 moonlight-auth  = { workspace = true}
 moonlight-errors = { workspace = true}
+moonlight-helpers = { workspace = true}
 moonlight-primitives  = { workspace = true}
 
 

--- a/contracts/channel-auth/src/contract.rs
+++ b/contracts/channel-auth/src/contract.rs
@@ -1,5 +1,6 @@
 use moonlight_auth::core::{ProviderAuthorizable, UtxoAuthorizable};
 use moonlight_errors::Error as MoonlightError;
+use moonlight_helpers::parser::address_to_ed25519_pk_bytes;
 
 use moonlight_primitives::Signatures;
 use soroban_sdk::{
@@ -109,8 +110,18 @@ impl ChannelAuthContract {
         <Self as ProviderAuthorizable>::is_provider(e, provider)
     }
 
+    /// Registers a provider. Only an Ed25519 account address can be registered: the provider
+    /// check in `require_provider` matches exclusively addresses derived from `SignerKey::
+    /// Provider` Ed25519 keys, so any other address kind (e.g. a contract address) would be
+    /// registered — and reported registered by `is_provider` — yet could never authorize
+    /// anything (RV audit B7).
+    ///
+    /// ### Panics
+    /// - Panics `NotEd25519AccountAddress` if `provider` is a contract address.
+    /// - Panics if the provider is already registered.
     pub fn add_provider(e: &Env, provider: Address) {
         ownable::enforce_owner_auth(e);
+        address_to_ed25519_pk_bytes(e, &provider);
         let addr = provider.clone();
         Self::register_provider(e, provider);
         ProviderAdded { provider: addr }.publish(e);

--- a/contracts/channel-auth/src/tests/events.rs
+++ b/contracts/channel-auth/src/tests/events.rs
@@ -1,3 +1,4 @@
+use moonlight_helpers::testutils::keys::Ed25519Account;
 use soroban_sdk::{
     testutils::{Address as _, Events, MockAuth, MockAuthInvoke},
     Address, Env, Event, IntoVal,
@@ -102,7 +103,7 @@ fn test_constructor_emits_initialized_event() {
 fn test_add_provider_emits_event() {
     let e = Env::default();
     let (client, admin) = create_contract(&e);
-    let provider = Address::generate(&e);
+    let provider = Ed25519Account::generate(&e).address;
 
     add_provider_with_auth(&client, &admin, &provider, &e);
 
@@ -118,7 +119,7 @@ fn test_add_provider_emits_event() {
 fn test_remove_provider_emits_event() {
     let e = Env::default();
     let (client, admin) = create_contract(&e);
-    let provider = Address::generate(&e);
+    let provider = Ed25519Account::generate(&e).address;
 
     add_provider_with_auth(&client, &admin, &provider, &e);
     remove_provider_with_auth(&client, &admin, &provider, &e);
@@ -135,7 +136,7 @@ fn test_remove_provider_emits_event() {
 fn test_provider_lifecycle_with_events() {
     let e = Env::default();
     let (client, admin) = create_contract(&e);
-    let provider = Address::generate(&e);
+    let provider = Ed25519Account::generate(&e).address;
 
     add_provider_with_auth(&client, &admin, &provider, &e);
     assert!(client.is_provider(&provider));

--- a/contracts/channel-auth/src/tests/tests.rs
+++ b/contracts/channel-auth/src/tests/tests.rs
@@ -24,12 +24,33 @@ pub fn create_contract(e: &Env) -> (ChannelAuthContractClient<'_>, Address) {
 }
 
 #[test]
+fn test_add_provider_rejects_contract_address() {
+    let e = Env::default();
+    let (auth_client, _admin) = create_contract(&e);
+    // Address::generate produces a contract address — the kind `require_provider` can never
+    // match (RV audit B7).
+    let contract_addr = Address::generate(&e);
+
+    let rejected = auth_client
+        .mock_all_auths()
+        .try_add_provider(&contract_addr);
+
+    assert!(rejected.is_err());
+    assert!(!auth_client.is_provider(&contract_addr));
+
+    // An Ed25519 account address is accepted.
+    let provider = Ed25519Account::generate(&e);
+    auth_client.mock_all_auths().add_provider(&provider.address);
+    assert!(auth_client.is_provider(&provider.address));
+}
+
+#[test]
 fn test_admin_transfer_keeps_current_admin_in_control_until_acceptance() {
     let e = Env::default();
     let (auth_client, admin) = create_contract(&e);
     let pending_admin = Address::generate(&e);
-    let provider = Address::generate(&e);
-    let blocked_provider = Address::generate(&e);
+    let provider = Ed25519Account::generate(&e).address;
+    let blocked_provider = Ed25519Account::generate(&e).address;
 
     auth_client
         .mock_auths(&[MockAuth {
@@ -81,8 +102,8 @@ fn test_admin_transfer_requires_pending_admin_to_accept() {
     let (auth_client, admin) = create_contract(&e);
     let pending_admin = Address::generate(&e);
     let non_pending_admin = Address::generate(&e);
-    let old_admin_provider = Address::generate(&e);
-    let new_admin_provider = Address::generate(&e);
+    let old_admin_provider = Ed25519Account::generate(&e).address;
+    let new_admin_provider = Ed25519Account::generate(&e).address;
 
     auth_client
         .mock_auths(&[MockAuth {

--- a/modules/auth/src/core.rs
+++ b/modules/auth/src/core.rs
@@ -86,6 +86,13 @@ pub trait UtxoAuthorizable {
                     // requirements, but it must only skip THIS context — never short-circuit the
                     // whole check. A `return Ok(())` here would let an empty-args context that
                     // precedes a spend-bearing context bypass the latter's P256 verification.
+                    //
+                    // RV audit B8 (deliberate): because argument-less contexts skip the UTXO
+                    // check entirely, their only gate is the single provider signature verified
+                    // by `require_provider`. This is intended for the channel's spend-free path
+                    // (bundles with no UTXO spends). A contract should name this account as
+                    // authorizer only where a one-provider-signature gate on an argument-less
+                    // invocation is acceptable.
                     continue;
                 }
 
@@ -105,6 +112,14 @@ pub trait UtxoAuthorizable {
                     }
 
                     match signer.clone() {
+                        // RV audit B9: the P256 verification below carries no replay protection
+                        // of its own — `__check_auth` keeps no nonce or used-signature state, so
+                        // an identical (conditions, valid_until_ledger, signature) tuple verifies
+                        // again on every call until expiry. Single-use must come from the
+                        // requesting contract: the privacy channel provides it by tombstoning
+                        // each spent UTXO, so a replayed spend fails there. Any other contract
+                        // naming this account as authorizer must supply its own single-use
+                        // mechanism.
                         SignerKey::P256(_signer_pk) => {
                             // Lookup signature by key.
 
@@ -212,6 +227,13 @@ pub trait ProviderAuthorizable {
                     Self::is_provider(&e, provider_addr.clone()),
                     Error::ProviderNotRegistered
                 );
+                // RV audit B6: this `valid_until_ledger` comes from the Signatures map, which
+                // the transaction submitter assembles — it is NOT covered by the provider's
+                // Ed25519 signature. That signature is verified against `payload`, the host's
+                // authorization-entry preimage, whose signature_expiration_ledger the host
+                // itself enforces; the binding provider deadline lives there. This in-contract
+                // check is a second, non-binding deadline the submitter can set freely — do not
+                // read it as a provider-signed expiry.
                 let (sig_variant, valid_until_ledger) =
                     sig_map.get(signer.clone()).ok_or(Error::MissingSignature)?;
 


### PR DESCRIPTION
Addresses the four informational RV findings in the provider/auth layer. Three are document-the-behavior; one (B7) is a small code fix. No version bump; held for internal review.

## B7 (code fix)

`add_provider` stored any `Address` without validating its kind, but the provider check in `require_provider` only ever matches an Ed25519 account address derived from the signer key — a contract address was accepted and reported registered while granting nothing. `add_provider` now validates the address via the existing `address_to_ed25519_pk_bytes` helper (panics `NotEd25519AccountAddress` on a contract address). No new error code.

- New test: `test_add_provider_rejects_contract_address` (contract address rejected, Ed25519 account address accepted).
- Existing channel-auth tests that used `Address::generate` (a contract address) as the provider now use Ed25519 account addresses.
- `moonlight-helpers` promoted from dev-dependency to dependency of channel-auth (already a workspace member and already compiled into the sibling modules).

## B6, B8, B9 (documentation)

Each behavior is documented at its code site in `modules/auth/src/core.rs` and as a known-constraint entry in `contracts/arch.md` §4.1 (mirroring the existing CA-7 gap note pattern):

- **B6** — the provider `valid_until_ledger` in the `Signatures` map is submitter-supplied, not provider-signed; the enforced provider deadline is the host-layer `signature_expiration_ledger` over the signed authorization preimage. The in-contract check is a second, non-binding deadline.
- **B8** — argument-less auth contexts skip the UTXO check (deliberate, MOON-03), so their only gate is one provider signature; intended for the channel's spend-free path.
- **B9** — P256 signatures verified by the UTXO check carry no replay protection of their own; single-use is provided by the requesting contract (the channel's UTXO tombstone), not by `__check_auth`.

## Verification

- `cargo test`: all suites green (57 tests). Note: main's fresh-lock test compile is broken by `ed25519-dalek` 3.0.0 resolution in `soroban-env-host`; worked around with a local-only `cargo update -p ed25519-dalek@3.0.0 --precise 2.2.0`. No lockfile committed.
- `cargo fmt --check`: clean on all touched files (a pre-existing drift exists on main in `modules/storage/src/lib.rs`, untouched here).
- `stellar contract build`: green.