### PR TITLE
chore: release 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ authors = ["Moonlight"]
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/Moonlight-Protocol/soroban-core"
-version = "0.4.0"
+version = "0.5.0"
 
 
 [workspace.dependencies]


### PR DESCRIPTION
Version bump for the merged RV audit batch (A1-A3, B1-B12). Auto-tag fires the release on merge.